### PR TITLE
Add tiered MIPS32-to-native JIT for 64-bit Android

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -187,6 +187,7 @@ jobs:
           cp target/i686-linux-android/release/libdingooemu.so "$out/x86/dingooemu_libretro_android.so"
           cp target/x86_64-linux-android/release/libdingooemu.so "$out/x86_64/dingooemu_libretro_android.so"
           cp crates/dingooemu-libretro/dingooemu_libretro.info "$out/"
+          cp LICENSE THIRD_PARTY_LICENSES.md "$out/"
           ls -laR "$out"
 
       - name: Package libretro

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,7 @@ jobs:
           cp target/i686-linux-android/release/libdingooemu.so "$out/x86/dingooemu_libretro_android.so"
           cp target/x86_64-linux-android/release/libdingooemu.so "$out/x86_64/dingooemu_libretro_android.so"
           cp crates/dingooemu-libretro/dingooemu_libretro.info "$out/"
+          cp LICENSE THIRD_PARTY_LICENSES.md "$out/"
           ls -laR "$out"
 
       - name: Package libretro

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "alsa"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,9 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -414,7 +423,7 @@ dependencies = [
  "jni",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.5.0",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -440,6 +449,186 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741d806a79cf99eaf51384a8800bbb4252a0428d6a29cdba1ab7e93b2c7ddb41"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-module",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+dependencies = [
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+
+[[package]]
+name = "cranelift-control"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+dependencies = [
+ "cranelift-bitset",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+dependencies = [
+ "cranelift-codegen",
+ "hashbrown 0.17.1",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2336d9ac773a092b1bff25988b298fe47d7921c2e6019d8243f5bb52d1c78d0d"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "memmap2",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c89882b932e6ae6b9c9a9c0d4ee784c53208d2db5cccb6e099e298cf35572cf"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.134.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
 
 [[package]]
 name = "crc32fast"
@@ -540,6 +729,10 @@ dependencies = [
  "bincode",
  "byteorder",
  "cargo-husky",
+ "cranelift",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
  "crc32fast",
  "env_logger",
  "image",
@@ -717,6 +910,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +1044,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,9 +1068,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -908,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1133,6 +1359,15 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
@@ -1155,6 +1390,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1758,6 +2002,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2045,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2 0.4.3",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +2083,12 @@ name = "rtrb"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -2129,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2616,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "47.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "47.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2563,7 +2867,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2581,13 +2894,29 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2606,10 +2935,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2618,10 +2959,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2630,16 +2989,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ clap = { version = "=4.6.5", features = ["derive"] }
 minifb = "=0.28.0"
 rodio = { version = "=0.22.2", features = ["mp3"] }
 env_logger = "=0.11.11"
+cranelift = "=0.134.3"
+cranelift-jit = "=0.134.3"
+cranelift-module = "=0.134.3"
+cranelift-native = "=0.134.3"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dingoo A320 is a handheld game console powered by the Ingenic JZ4740 MIPS SoC. T
 
 ## Features
 
-- **Cached MIPS32 CPU interpreter** — Direct-mapped instruction blocks with Ingenic JZ4740 XBurst compatibility
+- **Tiered MIPS32 CPU execution** — Cached interpreter on every platform, plus native translation of hot blocks on 64-bit Android
 - **Real-time scheduling** — Guest timing stays at 60 Hz without requiring one host-side dispatch per hardware clock cycle
 - **HLE (High-Level Emulation)** — Dingoo SDK functions for graphics, focused-window key callbacks, audio, timing, files, and companion-content discovery implemented in Rust
 - **Auditable compatibility diagnostics** — Aggregate unknown SDK calls and produce machine-graded L0/L1/L2/L3 JSON and CSV reports with deterministic input and PCM checkpoints
@@ -116,6 +116,7 @@ crates/
 │       │       ├── tasks.rs     # Tasks and semaphores
 │       │       └── system.rs    # Memory, timing, and system calls
 │       ├── cpu.rs               # Cached-block MIPS32 CPU interpreter
+│       ├── jit.rs               # Optional native translator for hot MIPS32 blocks
 │       ├── memory.rs            # Memory bus (32MB address space)
 │       ├── video.rs             # Framebuffer and screen rendering
 │       ├── audio.rs             # Audio engine (PCM output)

--- a/README.md
+++ b/README.md
@@ -168,3 +168,5 @@ Contributions are welcome! Whether you're interested in fixing bugs, adding feat
 ## License
 
 This project is licensed under the [BSD 3-Clause License](LICENSE).
+JIT-enabled Android binaries also contain compatible third-party components;
+their complete terms are included in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,267 @@
+# JIT Third-Party Licenses
+
+DingooEmu's own source code remains licensed under the BSD 3-Clause License
+in `LICENSE`. JIT-enabled Android binaries additionally incorporate the
+following compatible third-party components:
+
+- Cranelift and Wasmtime internal support crates: Apache-2.0 WITH LLVM-exception
+- `region`: MIT
+
+The complete license texts distributed by those crates follow.
+
+## Cranelift and Wasmtime
+
+```text
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+
+```
+
+## region
+
+```text
+Copyright (c) 2016 Elliott Linder
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```

--- a/crates/dingooemu-core/Cargo.toml
+++ b/crates/dingooemu-core/Cargo.toml
@@ -17,6 +17,10 @@ lz4_flex.workspace = true
 byteorder = "1"
 image.workspace = true
 rodio = { workspace = true, optional = true }
+cranelift = { workspace = true, optional = true }
+cranelift-jit = { workspace = true, optional = true }
+cranelift-module = { workspace = true, optional = true }
+cranelift-native = { workspace = true, optional = true }
 
 [dev-dependencies]
 env_logger.workspace = true
@@ -24,3 +28,9 @@ cargo-husky = { version = "=1.5.0", default-features = false, features = ["preco
 
 [features]
 standalone = ["dep:rodio"]
+jit = [
+    "dep:cranelift",
+    "dep:cranelift-jit",
+    "dep:cranelift-module",
+    "dep:cranelift-native",
+]

--- a/crates/dingooemu-core/src/cpu.rs
+++ b/crates/dingooemu-core/src/cpu.rs
@@ -9,6 +9,7 @@ pub enum UnknownInstructionPolicy {
 }
 
 /// MIPS32 register file
+#[repr(C)]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Registers {
     /// General purpose registers (R0-R31)

--- a/crates/dingooemu-core/src/emulator.rs
+++ b/crates/dingooemu-core/src/emulator.rs
@@ -4,6 +4,8 @@ use crate::cheats::{CheatManager, CheatParseError, CheatRule};
 use crate::cpu::Cpu;
 use crate::error::{Result, SimulatorError};
 use crate::input::Input;
+#[cfg(feature = "jit")]
+use crate::jit::JitEngine;
 use crate::memory::Memory;
 use crate::video::Video;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -259,6 +261,9 @@ pub struct Emulator {
     hook_filter: Box<[u64]>,
     /// Direct-mapped cache of sequential guest instruction blocks
     instruction_blocks: Box<[CachedInstructionBlock]>,
+    /// Native code cache for hot MIPS instruction blocks
+    #[cfg(feature = "jit")]
+    jit: JitEngine,
     /// Open guest resource files
     open_files: HashMap<u32, OpenFile>,
     /// Host directory used for persistent guest-created files
@@ -404,6 +409,8 @@ impl Emulator {
             unknown_hle_calls: BTreeMap::new(),
             hook_filter,
             instruction_blocks: empty_instruction_block_cache(),
+            #[cfg(feature = "jit")]
+            jit: JitEngine::new(),
             open_files: HashMap::new(),
             save_directory,
             next_file_handle: 1,
@@ -686,6 +693,8 @@ impl Emulator {
 
     /// Run one frame of emulation
     pub fn tick(&mut self) -> Result<()> {
+        #[cfg(feature = "jit")]
+        self.jit.begin_frame();
         self.framebuffer_submitted = false;
         self.cheats.apply(&mut self.memory, &mut self.cpu);
 
@@ -800,6 +809,25 @@ impl Emulator {
         self.ensure_instruction_block(start)?;
         let instruction_limit = (remaining_cycles / CPU_CYCLES_PER_INSTRUCTION) as usize;
         let cache_index = instruction_block_cache_index(start);
+
+        #[cfg(feature = "jit")]
+        if !self.cpu.branch_delay {
+            let block = &self.instruction_blocks[cache_index];
+            let ram = self.memory.jit_ram_ptr();
+            let framebuffer = self.memory.jit_framebuffer_ptr();
+            if let Some(completed) = self.jit.execute(
+                start,
+                &block.instructions[..block.len as usize],
+                instruction_limit,
+                &mut self.cpu.regs,
+                ram,
+                framebuffer,
+            ) {
+                self.cpu.account_instructions(completed);
+                return Ok(completed);
+            }
+        }
+
         let block = &self.instruction_blocks[cache_index];
         let mut completed = 0u64;
 
@@ -872,6 +900,16 @@ impl Emulator {
         for block in &mut self.instruction_blocks {
             block.len = 0;
         }
+        #[cfg(feature = "jit")]
+        self.jit.clear();
+    }
+
+    /// Enable or disable native translation of hot CPU blocks.
+    pub fn set_jit_enabled(&mut self, enabled: bool) {
+        #[cfg(feature = "jit")]
+        self.jit.set_enabled(enabled);
+        #[cfg(not(feature = "jit"))]
+        let _ = enabled;
     }
 
     fn active_context_waiting(&mut self) -> bool {
@@ -1868,6 +1906,8 @@ impl Default for Emulator {
             unknown_hle_calls: BTreeMap::new(),
             hook_filter: vec![0; HOOK_FILTER_WORDS].into_boxed_slice(),
             instruction_blocks: empty_instruction_block_cache(),
+            #[cfg(feature = "jit")]
+            jit: JitEngine::new(),
             open_files: HashMap::new(),
             save_directory: None,
             next_file_handle: 1,
@@ -2054,6 +2094,71 @@ mod tests {
             CYCLES_PER_FRAME / CPU_CYCLES_PER_INSTRUCTION
         );
         assert_eq!(emu.cycle_count, CYCLES_PER_FRAME);
+    }
+
+    #[cfg(feature = "jit")]
+    #[test]
+    #[ignore = "manual JIT throughput benchmark"]
+    fn benchmark_jit_hot_integer_loop() {
+        fn make_emulator(jit_enabled: bool, block_count: u32) -> Emulator {
+            let mut emu = Emulator::default();
+            for block_index in 0..block_count {
+                let block_address = 0x8000_0000 + block_index * 64;
+                let next_address = 0x8000_0000 + ((block_index + 1) % block_count) * 64;
+                let instructions = [
+                    (0x09 << 26) | (8 << 21) | (8 << 16) | 1,
+                    (9 << 21) | (8 << 16) | (9 << 11) | 0x21,
+                    (9 << 21) | (8 << 16) | (10 << 11) | 0x26,
+                    (10 << 21) | (8 << 16) | (11 << 11) | 0x25,
+                    (11 << 16) | (12 << 11) | (3 << 6),
+                    (12 << 16) | (13 << 11) | (2 << 6) | 0x02,
+                    (13 << 21) | (8 << 16) | (14 << 11) | 0x24,
+                    (0x2b << 26) | (14 << 16) | 0x0200,
+                    (0x23 << 26) | (15 << 16) | 0x0200,
+                    (15 << 21) | (8 << 16) | (16 << 11) | 0x23,
+                    (0x0d << 26) | (16 << 21) | (17 << 16) | 0x55aa,
+                    (0x0e << 26) | (17 << 21) | (18 << 16) | 0xa55a,
+                    (18 << 21) | (8 << 16) | (19 << 11) | 0x2b,
+                    (19 << 21) | (9 << 16) | (20 << 11) | 0x21,
+                    (0x02 << 26) | ((next_address >> 2) & 0x03ff_ffff),
+                    0,
+                ];
+                for (index, instruction) in instructions.into_iter().enumerate() {
+                    emu.memory
+                        .write_u32(block_address + (index as u32) * 4, instruction)
+                        .unwrap();
+                }
+            }
+            emu.set_jit_enabled(jit_enabled);
+            emu.start();
+            emu
+        }
+
+        fn measure(mut emu: Emulator) -> (std::time::Duration, std::time::Duration) {
+            let cold_start = std::time::Instant::now();
+            emu.tick().unwrap();
+            let cold = cold_start.elapsed();
+            let warm_start = std::time::Instant::now();
+            for _ in 0..5 {
+                emu.tick().unwrap();
+            }
+            (cold, warm_start.elapsed())
+        }
+
+        let (interpreter_cold, interpreter_warm) = measure(make_emulator(false, 1));
+        let (jit_cold, jit_warm) = measure(make_emulator(true, 1));
+        eprintln!(
+            "cold: interpreter={interpreter_cold:?} jit={jit_cold:?} ratio={:.2}x; warm: interpreter={interpreter_warm:?} jit={jit_warm:?} speedup={:.2}x",
+            jit_cold.as_secs_f64() / interpreter_cold.as_secs_f64(),
+            interpreter_warm.as_secs_f64() / jit_warm.as_secs_f64()
+        );
+        let (many_interpreter_cold, many_interpreter_warm) = measure(make_emulator(false, 64));
+        let (many_jit_cold, many_jit_warm) = measure(make_emulator(true, 64));
+        eprintln!(
+            "64 blocks cold: interpreter={many_interpreter_cold:?} jit={many_jit_cold:?} ratio={:.2}x; warm: interpreter={many_interpreter_warm:?} jit={many_jit_warm:?} ratio={:.2}x",
+            many_jit_cold.as_secs_f64() / many_interpreter_cold.as_secs_f64(),
+            many_jit_warm.as_secs_f64() / many_interpreter_warm.as_secs_f64()
+        );
     }
 
     #[test]

--- a/crates/dingooemu-core/src/jit.rs
+++ b/crates/dingooemu-core/src/jit.rs
@@ -114,6 +114,22 @@ impl JitEngine {
     pub(crate) fn clear(&mut self) {
         self.entries.clear();
         self.fast_entries.fill(FastJitCacheEntry::default());
+        if self.compiled_block_count != 0 {
+            // Discard every function pointer before dropping the module that owns it.
+            if let Some(compiler) = self.compiler.take() {
+                drop(compiler);
+                self.compiler = match Compiler::new() {
+                    Ok(compiler) => Some(compiler),
+                    Err(error) => {
+                        log::warn!(
+                            "MIPS JIT backend unavailable after cache invalidation: {error}"
+                        );
+                        None
+                    }
+                };
+            }
+            self.compiled_block_count = 0;
+        }
         self.compile_budget = 1;
         self.compile_cooldown = 0;
     }
@@ -1282,6 +1298,45 @@ mod tests {
             .is_some());
         assert!(engine.entries[&first_start].block.is_some());
         assert!(engine.entries[&second_start].block.is_some());
+    }
+
+    #[test]
+    fn clearing_cache_recreates_compiler_after_native_code_generation() {
+        let instructions = [
+            (0x09 << 26) | (8 << 16) | 1,
+            (0x09 << 26) | (8 << 21) | (8 << 16) | 1,
+            (8 << 21) | (8 << 16) | (9 << 11) | 0x21,
+            (9 << 21) | (8 << 16) | (10 << 11) | 0x26,
+        ];
+        let start = 0x1000;
+        let mut engine = JitEngine::new();
+        let mut registers = Registers::new(start);
+        let mut memory = Memory::new();
+        let ram = memory.jit_ram_ptr();
+        let framebuffer = memory.jit_framebuffer_ptr();
+
+        for _ in 0..HOT_BLOCK_THRESHOLD {
+            let _ = engine.execute(
+                start,
+                &instructions,
+                instructions.len(),
+                &mut registers,
+                ram,
+                framebuffer,
+            );
+        }
+        assert_eq!(engine.compiled_block_count, 1);
+        assert_eq!(engine.compiler.as_ref().unwrap().next_function_id, 1);
+
+        engine.clear();
+
+        assert!(engine.entries.is_empty());
+        assert!(engine
+            .fast_entries
+            .iter()
+            .all(|entry| entry.block.is_none()));
+        assert_eq!(engine.compiled_block_count, 0);
+        assert_eq!(engine.compiler.as_ref().unwrap().next_function_id, 0);
     }
 
     #[test]

--- a/crates/dingooemu-core/src/jit.rs
+++ b/crates/dingooemu-core/src/jit.rs
@@ -1,0 +1,1435 @@
+use crate::cpu::Registers;
+use cranelift::codegen::ir::{
+    types, AbiParam, Function, InstBuilder, MemFlagsData, Signature, Value,
+};
+use cranelift::codegen::settings::{self, Configurable};
+use cranelift::frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift::prelude::IntCC;
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{default_libcall_names, Linkage, Module};
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
+use std::mem::{offset_of, transmute};
+use std::time::Instant;
+
+const HOT_BLOCK_THRESHOLD: u16 = 256;
+const MIN_COMPILED_BLOCK_LEN: usize = 4;
+const MAX_JIT_CACHE_ENTRIES: usize = 32_768;
+const FAST_JIT_CACHE_SLOTS: usize = 4_096;
+const MAX_ZERO_INSTRUCTION_EXITS: u8 = 4;
+const COMPILE_COOLDOWN_FRAMES: u8 = 3;
+const REGISTER_COUNT: usize = 34;
+const HI_INDEX: usize = 32;
+const LO_INDEX: usize = 33;
+const KSEG_MASK: u32 = 0x1fff_ffff;
+
+type JitBlockFn = unsafe extern "C" fn(*mut Registers, *mut u8, *mut u8) -> u64;
+
+#[derive(Clone, Copy)]
+struct CompiledBlock {
+    function: JitBlockFn,
+    instruction_count: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+struct FastJitCacheEntry {
+    start: u32,
+    block: Option<CompiledBlock>,
+}
+
+#[derive(Default)]
+struct JitCacheEntry {
+    hits: u16,
+    failed: bool,
+    zero_instruction_exits: u8,
+    block: Option<CompiledBlock>,
+}
+
+#[derive(Default)]
+struct GuestAddressHasher(u64);
+
+impl Hasher for GuestAddressHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0 = bytes.iter().fold(0, |hash, &byte| {
+            hash.wrapping_mul(16777619) ^ u64::from(byte)
+        });
+    }
+
+    fn write_u32(&mut self, value: u32) {
+        self.0 = u64::from(value >> 2);
+    }
+}
+
+type JitEntryMap = HashMap<u32, JitCacheEntry, BuildHasherDefault<GuestAddressHasher>>;
+
+struct Compiler {
+    module: JITModule,
+    context: cranelift::codegen::Context,
+    builder_context: FunctionBuilderContext,
+    next_function_id: u64,
+}
+
+pub(crate) struct JitEngine {
+    compiler: Option<Compiler>,
+    entries: JitEntryMap,
+    fast_entries: Box<[FastJitCacheEntry]>,
+    enabled: bool,
+    compile_budget: u8,
+    compile_cooldown: u8,
+    compiled_block_count: u64,
+}
+
+impl JitEngine {
+    pub(crate) fn new() -> Self {
+        let compiler = match Compiler::new() {
+            Ok(compiler) => {
+                log::info!("MIPS JIT backend initialized");
+                Some(compiler)
+            }
+            Err(error) => {
+                log::warn!("MIPS JIT backend unavailable: {error}");
+                None
+            }
+        };
+        Self {
+            compiler,
+            entries: HashMap::with_capacity_and_hasher(4_096, BuildHasherDefault::default()),
+            fast_entries: vec![FastJitCacheEntry::default(); FAST_JIT_CACHE_SLOTS]
+                .into_boxed_slice(),
+            enabled: true,
+            compile_budget: 1,
+            compile_cooldown: 0,
+            compiled_block_count: 0,
+        }
+    }
+
+    pub(crate) fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+        self.fast_entries.fill(FastJitCacheEntry::default());
+        self.compile_budget = 1;
+        self.compile_cooldown = 0;
+    }
+
+    pub(crate) fn begin_frame(&mut self) {
+        if self.compile_cooldown == 0 {
+            self.compile_budget = 1;
+        } else {
+            self.compile_cooldown -= 1;
+            self.compile_budget = 0;
+        }
+    }
+
+    pub(crate) fn execute(
+        &mut self,
+        start: u32,
+        instructions: &[u32],
+        instruction_limit: usize,
+        registers: &mut Registers,
+        ram: *mut u8,
+        framebuffer: *mut u8,
+    ) -> Option<u64> {
+        if !self.enabled || instruction_limit == 0 || self.compiler.is_none() {
+            return None;
+        }
+
+        let fast_index = (start as usize >> 2) & (FAST_JIT_CACHE_SLOTS - 1);
+        let fast_entry = self.fast_entries[fast_index];
+        if fast_entry.start == start {
+            if let Some(block) = fast_entry.block {
+                let completed =
+                    execute_compiled_block(block, instruction_limit, registers, ram, framebuffer);
+                if let Some(completed) = completed {
+                    if completed != 0 {
+                        return Some(completed);
+                    }
+                    if let Some(entry) = self.entries.get_mut(&start) {
+                        entry.zero_instruction_exits =
+                            entry.zero_instruction_exits.saturating_add(1);
+                        if entry.zero_instruction_exits >= MAX_ZERO_INSTRUCTION_EXITS {
+                            entry.block = None;
+                            entry.failed = true;
+                            self.fast_entries[fast_index].block = None;
+                        }
+                    }
+                }
+                return None;
+            }
+        }
+
+        let at_capacity = self.entries.len() >= MAX_JIT_CACHE_ENTRIES;
+        let entry = match self.entries.entry(start) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                if at_capacity {
+                    return None;
+                }
+                entry.insert(JitCacheEntry::default())
+            }
+        };
+
+        if let Some(block) = entry.block {
+            self.fast_entries[fast_index] = FastJitCacheEntry {
+                start,
+                block: Some(block),
+            };
+            let completed =
+                execute_compiled_block(block, instruction_limit, registers, ram, framebuffer);
+            if let Some(completed) = completed {
+                if completed == 0 {
+                    entry.zero_instruction_exits = entry.zero_instruction_exits.saturating_add(1);
+                    if entry.zero_instruction_exits >= MAX_ZERO_INSTRUCTION_EXITS {
+                        entry.block = None;
+                        entry.failed = true;
+                        self.fast_entries[fast_index].block = None;
+                    }
+                    return None;
+                }
+                entry.zero_instruction_exits = 0;
+                return Some(completed);
+            }
+            return None;
+        }
+        if entry.failed {
+            return None;
+        }
+
+        entry.hits = entry.hits.saturating_add(1);
+        if entry.hits < HOT_BLOCK_THRESHOLD || self.compile_budget == 0 {
+            return None;
+        }
+        if candidate_instruction_count(instructions) < MIN_COMPILED_BLOCK_LEN {
+            entry.failed = true;
+            return None;
+        }
+
+        self.compile_budget = 0;
+        self.compile_cooldown = COMPILE_COOLDOWN_FRAMES;
+        let compile_start = Instant::now();
+        let compile_result = self
+            .compiler
+            .as_mut()
+            .expect("compiler presence checked above")
+            .compile(start, instructions);
+        match compile_result {
+            Ok(Some(block)) => {
+                self.compiled_block_count = self.compiled_block_count.wrapping_add(1);
+                log::debug!(
+                    "JIT compiled block {start:#010x}: instructions={} elapsed_us={} total={}",
+                    block.instruction_count,
+                    compile_start.elapsed().as_micros(),
+                    self.compiled_block_count
+                );
+                entry.block = Some(block);
+                self.fast_entries[fast_index] = FastJitCacheEntry {
+                    start,
+                    block: Some(block),
+                };
+                execute_compiled_block(block, instruction_limit, registers, ram, framebuffer)
+                    .filter(|&count| count != 0)
+            }
+            Ok(None) => {
+                entry.failed = true;
+                None
+            }
+            Err(error) => {
+                log::warn!("Failed to compile MIPS block at {start:#010x}: {error}");
+                entry.failed = true;
+                None
+            }
+        }
+    }
+}
+
+fn execute_compiled_block(
+    block: CompiledBlock,
+    instruction_limit: usize,
+    registers: &mut Registers,
+    ram: *mut u8,
+    framebuffer: *mut u8,
+) -> Option<u64> {
+    if block.instruction_count > instruction_limit {
+        return None;
+    }
+    // SAFETY: Cranelift emitted this function with the exact signature below.
+    // Registers has a stable C layout and both pointers remain valid for the call.
+    let completed = unsafe { (block.function)(registers, ram, framebuffer) };
+    Some(completed)
+}
+
+fn candidate_instruction_count(instructions: &[u32]) -> usize {
+    let mut index = 0;
+    while index < instructions.len() {
+        let instruction = instructions[index];
+        if is_control_flow(instruction) {
+            return if index + 1 < instructions.len()
+                && is_supported_delay_instruction(instructions[index + 1])
+                && lowerable_branch(instruction)
+            {
+                index + 2
+            } else {
+                index
+            };
+        }
+        if !is_memory_instruction(instruction) && !is_supported_register_instruction(instruction) {
+            return index;
+        }
+        index += 1;
+    }
+    index
+}
+
+fn lowerable_branch(instruction: u32) -> bool {
+    match instruction >> 26 {
+        0 => matches!(instruction & 0x3f, 0x08 | 0x09),
+        0x01 => matches!((instruction >> 16) & 0x1f, 0x00 | 0x01 | 0x10 | 0x11),
+        0x02..=0x07 => true,
+        _ => false,
+    }
+}
+
+impl Compiler {
+    fn new() -> anyhow::Result<Self> {
+        let mut flag_builder = settings::builder();
+        flag_builder.set("opt_level", "speed")?;
+        flag_builder.set("enable_alias_analysis", "true")?;
+        let isa_builder = cranelift_native::builder()
+            .map_err(|error| anyhow::anyhow!("unsupported JIT host: {error}"))?;
+        let isa = isa_builder.finish(settings::Flags::new(flag_builder))?;
+        let builder = JITBuilder::with_isa(isa, default_libcall_names());
+        let module = JITModule::new(builder);
+        let context = module.make_context();
+        Ok(Self {
+            module,
+            context,
+            builder_context: FunctionBuilderContext::new(),
+            next_function_id: 0,
+        })
+    }
+
+    fn compile(
+        &mut self,
+        start: u32,
+        instructions: &[u32],
+    ) -> anyhow::Result<Option<CompiledBlock>> {
+        self.context.clear();
+        self.builder_context = FunctionBuilderContext::new();
+        let target_config = self.module.target_config();
+        let pointer_type = target_config.pointer_type();
+        debug_assert_eq!(pointer_type, types::I64);
+
+        let mut signature = Signature::new(target_config.default_call_conv);
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.params.push(AbiParam::new(pointer_type));
+        signature.returns.push(AbiParam::new(types::I64));
+        self.context.func = Function::with_name_signature(
+            cranelift::codegen::ir::UserFuncName::user(0, self.next_function_id as u32),
+            signature.clone(),
+        );
+
+        let instruction_count = {
+            let mut builder =
+                FunctionBuilder::new(&mut self.context.func, &mut self.builder_context);
+            let entry = builder.create_block();
+            builder.append_block_params_for_function_params(entry);
+            builder.switch_to_block(entry);
+            builder.seal_block(entry);
+            let registers = builder.block_params(entry)[0];
+            let ram = builder.block_params(entry)[1];
+            let framebuffer = builder.block_params(entry)[2];
+            let mut state = LoweringState::new(registers, ram, framebuffer);
+            let count = lower_block(&mut builder, &mut state, start, instructions);
+            if count != 0 {
+                builder.finalize(target_config);
+            }
+            count
+        };
+
+        if instruction_count == 0 {
+            return Ok(None);
+        }
+
+        let name = format!("jit_mips_block_{}", self.next_function_id);
+        self.next_function_id = self.next_function_id.wrapping_add(1);
+        let function_id = self
+            .module
+            .declare_function(&name, Linkage::Local, &signature)?;
+        self.module
+            .define_function(function_id, &mut self.context)?;
+        self.module.clear_context(&mut self.context);
+        self.module.finalize_definitions()?;
+        let code = self.module.get_finalized_function(function_id);
+        // SAFETY: The emitted function uses the JitBlockFn ABI and parameter types.
+        let function = unsafe { transmute::<*const u8, JitBlockFn>(code) };
+        Ok(Some(CompiledBlock {
+            function,
+            instruction_count,
+        }))
+    }
+}
+
+struct LoweringState {
+    registers: Value,
+    ram: Value,
+    framebuffer: Value,
+    values: [Option<Value>; REGISTER_COUNT],
+    dirty: [bool; REGISTER_COUNT],
+}
+
+impl LoweringState {
+    fn new(registers: Value, ram: Value, framebuffer: Value) -> Self {
+        Self {
+            registers,
+            ram,
+            framebuffer,
+            values: [None; REGISTER_COUNT],
+            dirty: [false; REGISTER_COUNT],
+        }
+    }
+}
+
+fn lower_block(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    start: u32,
+    instructions: &[u32],
+) -> usize {
+    let mut index = 0usize;
+    while index < instructions.len() {
+        let instruction = instructions[index];
+        if is_control_flow(instruction) {
+            if index + 1 >= instructions.len()
+                || !is_supported_delay_instruction(instructions[index + 1])
+            {
+                break;
+            }
+            let branch_pc = start.wrapping_add((index as u32).wrapping_mul(4));
+            let Some(target) = lower_branch(builder, state, instruction, branch_pc) else {
+                break;
+            };
+            if !lower_register_instruction(builder, state, instructions[index + 1]) {
+                break;
+            }
+            index += 2;
+            emit_exit(builder, state, target, index as u64);
+            return index;
+        }
+
+        if is_memory_instruction(instruction) {
+            let pc = start.wrapping_add((index as u32).wrapping_mul(4));
+            if !lower_memory_instruction(builder, state, instruction, pc, index as u64) {
+                break;
+            }
+        } else if !lower_register_instruction(builder, state, instruction) {
+            break;
+        }
+        index += 1;
+    }
+
+    if index != 0 {
+        let pc = iconst_u32(builder, start.wrapping_add((index as u32).wrapping_mul(4)));
+        emit_exit(builder, state, pc, index as u64);
+    }
+    index
+}
+
+fn is_control_flow(instruction: u32) -> bool {
+    let opcode = instruction >> 26;
+    matches!(opcode, 0x01..=0x07) || (opcode == 0 && matches!(instruction & 0x3f, 0x08 | 0x09))
+}
+
+fn is_supported_delay_instruction(instruction: u32) -> bool {
+    !is_control_flow(instruction)
+        && !is_memory_instruction(instruction)
+        && is_supported_register_instruction(instruction)
+}
+
+fn is_supported_register_instruction(instruction: u32) -> bool {
+    if instruction == 0 {
+        return true;
+    }
+    let opcode = instruction >> 26;
+    match opcode {
+        0 => matches!(
+            instruction & 0x3f,
+            0x00 | 0x02
+                | 0x03
+                | 0x04
+                | 0x06
+                | 0x07
+                | 0x0a
+                | 0x0b
+                | 0x0f
+                | 0x10
+                | 0x11
+                | 0x12
+                | 0x13
+                | 0x18
+                | 0x19
+                | 0x1a
+                | 0x1b
+                | 0x20..=0x27 | 0x2a | 0x2b
+        ),
+        0x08..=0x0f | 0x33 => true,
+        0x1c => matches!(
+            instruction & 0x3f,
+            0x00 | 0x01 | 0x02 | 0x04 | 0x05 | 0x20 | 0x21
+        ),
+        _ => false,
+    }
+}
+
+fn is_memory_instruction(instruction: u32) -> bool {
+    matches!(
+        instruction >> 26,
+        0x20 | 0x21
+            | 0x22
+            | 0x23
+            | 0x24
+            | 0x25
+            | 0x26
+            | 0x28
+            | 0x29
+            | 0x2a
+            | 0x2b
+            | 0x2e
+            | 0x30
+            | 0x38
+    )
+}
+
+fn lower_register_instruction(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    instruction: u32,
+) -> bool {
+    if instruction == 0 {
+        return true;
+    }
+    let opcode = instruction >> 26;
+    let rs = ((instruction >> 21) & 0x1f) as usize;
+    let rt = ((instruction >> 16) & 0x1f) as usize;
+    let rd = ((instruction >> 11) & 0x1f) as usize;
+    let shamt = (instruction >> 6) & 0x1f;
+
+    let result = match opcode {
+        0 => match instruction & 0x3f {
+            0x00 => {
+                let value = read_register(builder, state, rt);
+                Some((rd, builder.ins().ishl_imm_u(value, i64::from(shamt))))
+            }
+            0x02 => {
+                let value = read_register(builder, state, rt);
+                Some((rd, builder.ins().ushr_imm_u(value, i64::from(shamt))))
+            }
+            0x03 => {
+                let value = read_register(builder, state, rt);
+                Some((rd, builder.ins().sshr_imm_u(value, i64::from(shamt))))
+            }
+            0x04 | 0x06 | 0x07 => {
+                let value = read_register(builder, state, rt);
+                let shift = read_register(builder, state, rs);
+                let shift = builder.ins().band_imm_u(shift, 0x1f);
+                let shifted = match instruction & 0x3f {
+                    0x04 => builder.ins().ishl(value, shift),
+                    0x06 => builder.ins().ushr(value, shift),
+                    _ => builder.ins().sshr(value, shift),
+                };
+                Some((rd, shifted))
+            }
+            0x0a | 0x0b => {
+                let source = read_register(builder, state, rs);
+                let condition_value = read_register(builder, state, rt);
+                let current = read_register(builder, state, rd);
+                let condition = builder.ins().icmp_imm_u(
+                    if instruction & 0x3f == 0x0a {
+                        IntCC::Equal
+                    } else {
+                        IntCC::NotEqual
+                    },
+                    condition_value,
+                    0,
+                );
+                Some((rd, builder.ins().select(condition, source, current)))
+            }
+            0x0f => None,
+            0x10 => Some((rd, read_special_register(builder, state, HI_INDEX))),
+            0x11 => {
+                let value = read_register(builder, state, rs);
+                write_special_register(state, HI_INDEX, value);
+                None
+            }
+            0x12 => Some((rd, read_special_register(builder, state, LO_INDEX))),
+            0x13 => {
+                let value = read_register(builder, state, rs);
+                write_special_register(state, LO_INDEX, value);
+                None
+            }
+            0x18 | 0x19 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                let (left, right) = if instruction & 0x3f == 0x18 {
+                    (
+                        builder.ins().sextend(types::I64, left),
+                        builder.ins().sextend(types::I64, right),
+                    )
+                } else {
+                    (
+                        builder.ins().uextend(types::I64, left),
+                        builder.ins().uextend(types::I64, right),
+                    )
+                };
+                let product = builder.ins().imul(left, right);
+                write_i64_pair(builder, state, product);
+                None
+            }
+            0x1a | 0x1b => {
+                let numerator = read_register(builder, state, rs);
+                let denominator = read_register(builder, state, rt);
+                let zero = builder.ins().icmp_imm_u(IntCC::Equal, denominator, 0);
+                let invalid = if instruction & 0x3f == 0x1a {
+                    let minimum = iconst_u32(builder, i32::MIN as u32);
+                    let negative_one = iconst_u32(builder, u32::MAX);
+                    let is_minimum = builder.ins().icmp(IntCC::Equal, numerator, minimum);
+                    let is_negative_one =
+                        builder.ins().icmp(IntCC::Equal, denominator, negative_one);
+                    let overflow = builder.ins().band(is_minimum, is_negative_one);
+                    builder.ins().bor(zero, overflow)
+                } else {
+                    zero
+                };
+                let one = iconst_u32(builder, 1);
+                let safe_denominator = builder.ins().select(invalid, one, denominator);
+                let (quotient, remainder) = if instruction & 0x3f == 0x1a {
+                    (
+                        builder.ins().sdiv(numerator, safe_denominator),
+                        builder.ins().srem(numerator, safe_denominator),
+                    )
+                } else {
+                    (
+                        builder.ins().udiv(numerator, safe_denominator),
+                        builder.ins().urem(numerator, safe_denominator),
+                    )
+                };
+                let old_lo = read_special_register(builder, state, LO_INDEX);
+                let old_hi = read_special_register(builder, state, HI_INDEX);
+                let lo = builder.ins().select(invalid, old_lo, quotient);
+                let hi = builder.ins().select(invalid, old_hi, remainder);
+                write_special_register(state, LO_INDEX, lo);
+                write_special_register(state, HI_INDEX, hi);
+                None
+            }
+            0x20 | 0x21 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                Some((rd, builder.ins().iadd(left, right)))
+            }
+            0x22 | 0x23 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                Some((rd, builder.ins().isub(left, right)))
+            }
+            0x24 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                Some((rd, builder.ins().band(left, right)))
+            }
+            0x25 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                Some((rd, builder.ins().bor(left, right)))
+            }
+            0x26 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                Some((rd, builder.ins().bxor(left, right)))
+            }
+            0x27 => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                let value = builder.ins().bor(left, right);
+                Some((rd, builder.ins().bnot(value)))
+            }
+            0x2a | 0x2b => {
+                let left = read_register(builder, state, rs);
+                let right = read_register(builder, state, rt);
+                let condition = builder.ins().icmp(
+                    if instruction & 0x3f == 0x2a {
+                        IntCC::SignedLessThan
+                    } else {
+                        IntCC::UnsignedLessThan
+                    },
+                    left,
+                    right,
+                );
+                Some((rd, builder.ins().uextend(types::I32, condition)))
+            }
+            _ => return false,
+        },
+        0x08 | 0x09 => {
+            let source = read_register(builder, state, rs);
+            let immediate = iconst_u32(builder, instruction as i16 as i32 as u32);
+            Some((rt, builder.ins().iadd(source, immediate)))
+        }
+        0x0a | 0x0b => {
+            let source = read_register(builder, state, rs);
+            let immediate = iconst_u32(builder, instruction as i16 as i32 as u32);
+            let condition = builder.ins().icmp(
+                if opcode == 0x0a {
+                    IntCC::SignedLessThan
+                } else {
+                    IntCC::UnsignedLessThan
+                },
+                source,
+                immediate,
+            );
+            Some((rt, builder.ins().uextend(types::I32, condition)))
+        }
+        0x0c => {
+            let source = read_register(builder, state, rs);
+            Some((
+                rt,
+                builder
+                    .ins()
+                    .band_imm_u(source, i64::from(instruction as u16)),
+            ))
+        }
+        0x0d => {
+            let source = read_register(builder, state, rs);
+            Some((
+                rt,
+                builder
+                    .ins()
+                    .bor_imm_u(source, i64::from(instruction as u16)),
+            ))
+        }
+        0x0e => {
+            let source = read_register(builder, state, rs);
+            Some((
+                rt,
+                builder
+                    .ins()
+                    .bxor_imm_u(source, i64::from(instruction as u16)),
+            ))
+        }
+        0x0f => Some((rt, iconst_u32(builder, u32::from(instruction as u16) << 16))),
+        0x1c if matches!(
+            instruction & 0x3f,
+            0x00 | 0x01 | 0x02 | 0x04 | 0x05 | 0x20 | 0x21
+        ) =>
+        {
+            lower_special2(builder, state, instruction, rs, rt, rd);
+            None
+        }
+        0x33 => None,
+        _ => return false,
+    };
+
+    if let Some((register, value)) = result {
+        write_register(state, register, value);
+    }
+    true
+}
+
+fn lower_special2(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    instruction: u32,
+    rs: usize,
+    rt: usize,
+    rd: usize,
+) {
+    match instruction & 0x3f {
+        0x00 | 0x01 | 0x04 | 0x05 => {
+            let left = read_register(builder, state, rs);
+            let right = read_register(builder, state, rt);
+            let left = builder.ins().uextend(types::I64, left);
+            let right = builder.ins().uextend(types::I64, right);
+            let product = builder.ins().imul(left, right);
+            let hi = read_special_register(builder, state, HI_INDEX);
+            let lo = read_special_register(builder, state, LO_INDEX);
+            let hi = builder.ins().uextend(types::I64, hi);
+            let hi = builder.ins().ishl_imm_u(hi, 32);
+            let lo = builder.ins().uextend(types::I64, lo);
+            let accumulator = builder.ins().bor(hi, lo);
+            let result = if matches!(instruction & 0x3f, 0x00 | 0x01) {
+                builder.ins().iadd(accumulator, product)
+            } else {
+                builder.ins().isub(accumulator, product)
+            };
+            write_i64_pair(builder, state, result);
+        }
+        0x02 => {
+            let left = read_register(builder, state, rs);
+            let right = read_register(builder, state, rt);
+            let result = builder.ins().imul(left, right);
+            write_register(state, rd, result);
+        }
+        0x20 | 0x21 => {
+            let value = read_register(builder, state, rs);
+            let value = if instruction & 0x3f == 0x21 {
+                builder.ins().bnot(value)
+            } else {
+                value
+            };
+            let result = builder.ins().clz(value);
+            write_register(state, rd, result);
+        }
+        _ => unreachable!("instruction support checked before lowering"),
+    }
+}
+
+fn lower_branch(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    instruction: u32,
+    branch_pc: u32,
+) -> Option<Value> {
+    let opcode = instruction >> 26;
+    let rs = ((instruction >> 21) & 0x1f) as usize;
+    let rt = ((instruction >> 16) & 0x1f) as usize;
+    let fallthrough = branch_pc.wrapping_add(8);
+    let branch_target = branch_pc
+        .wrapping_add(4)
+        .wrapping_add(((instruction as i16 as i32) << 2) as u32);
+
+    match opcode {
+        0 => match instruction & 0x3f {
+            0x08 => Some(read_register(builder, state, rs)),
+            0x09 => {
+                let target = read_register(builder, state, rs);
+                write_register(
+                    state,
+                    ((instruction >> 11) & 0x1f) as usize,
+                    iconst_u32(builder, fallthrough),
+                );
+                Some(target)
+            }
+            _ => None,
+        },
+        0x01 => {
+            let kind = rt;
+            if matches!(kind, 0x10 | 0x11) {
+                let link = iconst_u32(builder, fallthrough);
+                write_register(state, 31, link);
+            }
+            let source = read_register(builder, state, rs);
+            let condition = match kind {
+                0x00 | 0x10 => builder.ins().icmp_imm_s(IntCC::SignedLessThan, source, 0),
+                0x01 | 0x11 => builder
+                    .ins()
+                    .icmp_imm_s(IntCC::SignedGreaterThanOrEqual, source, 0),
+                _ => return None,
+            };
+            Some(select_branch_target(
+                builder,
+                condition,
+                branch_target,
+                fallthrough,
+            ))
+        }
+        0x02 | 0x03 => {
+            if opcode == 0x03 {
+                let link = iconst_u32(builder, fallthrough);
+                write_register(state, 31, link);
+            }
+            Some(iconst_u32(
+                builder,
+                (branch_pc & 0xf000_0000) | ((instruction & 0x03ff_ffff) << 2),
+            ))
+        }
+        0x04 | 0x05 => {
+            let left = read_register(builder, state, rs);
+            let right = read_register(builder, state, rt);
+            let condition = builder.ins().icmp(
+                if opcode == 0x04 {
+                    IntCC::Equal
+                } else {
+                    IntCC::NotEqual
+                },
+                left,
+                right,
+            );
+            Some(select_branch_target(
+                builder,
+                condition,
+                branch_target,
+                fallthrough,
+            ))
+        }
+        0x06 | 0x07 => {
+            let source = read_register(builder, state, rs);
+            let condition = builder.ins().icmp_imm_s(
+                if opcode == 0x06 {
+                    IntCC::SignedLessThanOrEqual
+                } else {
+                    IntCC::SignedGreaterThan
+                },
+                source,
+                0,
+            );
+            Some(select_branch_target(
+                builder,
+                condition,
+                branch_target,
+                fallthrough,
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn select_branch_target(
+    builder: &mut FunctionBuilder<'_>,
+    condition: Value,
+    taken: u32,
+    fallthrough: u32,
+) -> Value {
+    let taken = iconst_u32(builder, taken);
+    let fallthrough = iconst_u32(builder, fallthrough);
+    builder.ins().select(condition, taken, fallthrough)
+}
+
+fn lower_memory_instruction(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    instruction: u32,
+    pc: u32,
+    completed: u64,
+) -> bool {
+    let opcode = instruction >> 26;
+    let rs = ((instruction >> 21) & 0x1f) as usize;
+    let rt = ((instruction >> 16) & 0x1f) as usize;
+    let width = match opcode {
+        0x20 | 0x24 | 0x28 => 1u32,
+        0x21 | 0x25 | 0x29 => 2,
+        0x22 | 0x23 | 0x26 | 0x2a | 0x2b | 0x2e | 0x30 | 0x38 => 4,
+        _ => return false,
+    };
+    let base = read_register(builder, state, rs);
+    let offset = iconst_u32(builder, instruction as i16 as i32 as u32);
+    let address = builder.ins().iadd(base, offset);
+    let unaligned = matches!(opcode, 0x22 | 0x26 | 0x2a | 0x2e);
+    let access_address = if unaligned {
+        builder.ins().band_imm_u(address, i64::from(!3u32))
+    } else {
+        address
+    };
+    let physical = translate_address(builder, access_address);
+    let ram_in_bounds = builder.ins().icmp_imm_u(
+        IntCC::UnsignedLessThanOrEqual,
+        physical,
+        i64::from(crate::memory::RAM_SIZE - width),
+    );
+    let physical_pointer = builder.ins().uextend(types::I64, physical);
+    let ram_address = builder.ins().iadd(state.ram, physical_pointer);
+    let fast = builder.create_block();
+    builder.append_block_param(fast, types::I64);
+    let check_framebuffer = builder.create_block();
+    let slow = builder.create_block();
+    let ram_args = [ram_address.into()];
+    builder
+        .ins()
+        .brif(ram_in_bounds, fast, &ram_args, check_framebuffer, &[]);
+
+    builder.switch_to_block(check_framebuffer);
+    builder.seal_block(check_framebuffer);
+    let mut framebuffer_address = state.framebuffer;
+    let mut mapped = None;
+    for base in crate::memory::LCD_FRAMEBUFFER_ALIASES {
+        let alias_offset = builder.ins().iadd_imm_s(access_address, -i64::from(base));
+        let alias_in_bounds = builder.ins().icmp_imm_u(
+            IntCC::UnsignedLessThanOrEqual,
+            alias_offset,
+            (crate::video::FRAMEBUFFER_MAP_SIZE as u32 - width) as i64,
+        );
+        let alias_pointer = builder.ins().uextend(types::I64, alias_offset);
+        let alias_address = builder.ins().iadd(state.framebuffer, alias_pointer);
+        framebuffer_address =
+            builder
+                .ins()
+                .select(alias_in_bounds, alias_address, framebuffer_address);
+        mapped = Some(match mapped {
+            Some(previous) => builder.ins().bor(previous, alias_in_bounds),
+            None => alias_in_bounds,
+        });
+    }
+    let framebuffer_args = [framebuffer_address.into()];
+    builder.ins().brif(
+        mapped.expect("framebuffer has at least one alias"),
+        fast,
+        &framebuffer_args,
+        slow,
+        &[],
+    );
+
+    builder.switch_to_block(slow);
+    builder.seal_block(slow);
+    let bailout_pc = iconst_u32(builder, pc);
+    emit_exit(builder, state, bailout_pc, completed);
+
+    builder.switch_to_block(fast);
+    builder.seal_block(fast);
+    let host_address = builder.block_params(fast)[0];
+    let flags = MemFlagsData::new();
+
+    match opcode {
+        0x20 | 0x21 | 0x23 | 0x24 | 0x25 | 0x30 => {
+            let load_type = match width {
+                1 => types::I8,
+                2 => types::I16,
+                _ => types::I32,
+            };
+            let value = builder.ins().load(load_type, flags, host_address, 0);
+            let value = match opcode {
+                0x20 | 0x21 => builder.ins().sextend(types::I32, value),
+                0x24 | 0x25 => builder.ins().uextend(types::I32, value),
+                _ => value,
+            };
+            write_register(state, rt, value);
+        }
+        0x22 | 0x26 => {
+            let memory = builder.ins().load(types::I32, flags, host_address, 0);
+            let current = read_register(builder, state, rt);
+            let byte = builder.ins().band_imm_u(address, 3);
+            let cases = if opcode == 0x22 {
+                [
+                    merge_shift_left(builder, memory, 24, current, 0x00ff_ffff),
+                    merge_shift_left(builder, memory, 16, current, 0x0000_ffff),
+                    merge_shift_left(builder, memory, 8, current, 0x0000_00ff),
+                    memory,
+                ]
+            } else {
+                [
+                    memory,
+                    merge_shift_right(builder, memory, 8, current, 0xff00_0000),
+                    merge_shift_right(builder, memory, 16, current, 0xffff_0000),
+                    merge_shift_right(builder, memory, 24, current, 0xffff_ff00),
+                ]
+            };
+            let value = select_byte_case(builder, byte, cases);
+            write_register(state, rt, value);
+        }
+        0x28 | 0x29 | 0x2b | 0x38 => {
+            let value = read_register(builder, state, rt);
+            let value = match width {
+                1 => builder.ins().ireduce(types::I8, value),
+                2 => builder.ins().ireduce(types::I16, value),
+                _ => value,
+            };
+            builder.ins().store(flags, value, host_address, 0);
+            if opcode == 0x38 {
+                let success = iconst_u32(builder, 1);
+                write_register(state, rt, success);
+            }
+        }
+        0x2a | 0x2e => {
+            let memory = builder.ins().load(types::I32, flags, host_address, 0);
+            let value = read_register(builder, state, rt);
+            let byte = builder.ins().band_imm_u(address, 3);
+            let cases = if opcode == 0x2a {
+                [
+                    merge_store_right(builder, memory, 0xffff_ff00, value, 24),
+                    merge_store_right(builder, memory, 0xffff_0000, value, 16),
+                    merge_store_right(builder, memory, 0xff00_0000, value, 8),
+                    value,
+                ]
+            } else {
+                [
+                    value,
+                    merge_store_left(builder, memory, 0x0000_00ff, value, 8),
+                    merge_store_left(builder, memory, 0x0000_ffff, value, 16),
+                    merge_store_left(builder, memory, 0x00ff_ffff, value, 24),
+                ]
+            };
+            let value = select_byte_case(builder, byte, cases);
+            builder.ins().store(flags, value, host_address, 0);
+        }
+        _ => return false,
+    }
+    true
+}
+
+fn merge_shift_left(
+    builder: &mut FunctionBuilder<'_>,
+    memory: Value,
+    shift: i64,
+    current: Value,
+    mask: u32,
+) -> Value {
+    let memory = builder.ins().ishl_imm_u(memory, shift);
+    let current = builder.ins().band_imm_u(current, i64::from(mask));
+    builder.ins().bor(memory, current)
+}
+
+fn merge_shift_right(
+    builder: &mut FunctionBuilder<'_>,
+    memory: Value,
+    shift: i64,
+    current: Value,
+    mask: u32,
+) -> Value {
+    let memory = builder.ins().ushr_imm_u(memory, shift);
+    let current = builder.ins().band_imm_u(current, i64::from(mask));
+    builder.ins().bor(memory, current)
+}
+
+fn merge_store_right(
+    builder: &mut FunctionBuilder<'_>,
+    memory: Value,
+    mask: u32,
+    value: Value,
+    shift: i64,
+) -> Value {
+    let memory = builder.ins().band_imm_u(memory, i64::from(mask));
+    let value = builder.ins().ushr_imm_u(value, shift);
+    builder.ins().bor(memory, value)
+}
+
+fn merge_store_left(
+    builder: &mut FunctionBuilder<'_>,
+    memory: Value,
+    mask: u32,
+    value: Value,
+    shift: i64,
+) -> Value {
+    let memory = builder.ins().band_imm_u(memory, i64::from(mask));
+    let value = builder.ins().ishl_imm_u(value, shift);
+    builder.ins().bor(memory, value)
+}
+
+fn select_byte_case(builder: &mut FunctionBuilder<'_>, byte: Value, cases: [Value; 4]) -> Value {
+    let mut result = cases[3];
+    for index in (0..3).rev() {
+        let matches = builder.ins().icmp_imm_u(IntCC::Equal, byte, index as i64);
+        result = builder.ins().select(matches, cases[index], result);
+    }
+    result
+}
+
+fn translate_address(builder: &mut FunctionBuilder<'_>, address: Value) -> Value {
+    let segment = builder
+        .ins()
+        .band_imm_u(address, i64::from(0xe000_0000_u32));
+    let kseg0 = iconst_u32(builder, 0x8000_0000);
+    let kseg1 = iconst_u32(builder, 0xa000_0000);
+    let is_kseg0 = builder.ins().icmp(IntCC::Equal, segment, kseg0);
+    let is_kseg1 = builder.ins().icmp(IntCC::Equal, segment, kseg1);
+    let masked = builder.ins().band_imm_u(address, i64::from(KSEG_MASK));
+    let physical = builder.ins().select(is_kseg0, masked, address);
+    builder.ins().select(is_kseg1, masked, physical)
+}
+
+fn read_register(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    register: usize,
+) -> Value {
+    if register == 0 {
+        return iconst_u32(builder, 0);
+    }
+    read_special_register(builder, state, register)
+}
+
+fn write_register(state: &mut LoweringState, register: usize, value: Value) {
+    if register != 0 {
+        write_special_register(state, register, value);
+    }
+}
+
+fn read_special_register(
+    builder: &mut FunctionBuilder<'_>,
+    state: &mut LoweringState,
+    register: usize,
+) -> Value {
+    if let Some(value) = state.values[register] {
+        return value;
+    }
+    let value = builder.ins().load(
+        types::I32,
+        MemFlagsData::new(),
+        state.registers,
+        register_offset(register),
+    );
+    state.values[register] = Some(value);
+    value
+}
+
+fn write_special_register(state: &mut LoweringState, register: usize, value: Value) {
+    state.values[register] = Some(value);
+    state.dirty[register] = true;
+}
+
+fn write_i64_pair(builder: &mut FunctionBuilder<'_>, state: &mut LoweringState, value: Value) {
+    let lo = builder.ins().ireduce(types::I32, value);
+    let hi = builder.ins().ushr_imm_u(value, 32);
+    let hi = builder.ins().ireduce(types::I32, hi);
+    write_special_register(state, LO_INDEX, lo);
+    write_special_register(state, HI_INDEX, hi);
+}
+
+fn register_offset(register: usize) -> i32 {
+    let offset = match register {
+        0..=31 => offset_of!(Registers, gpr) + register * std::mem::size_of::<u32>(),
+        HI_INDEX => offset_of!(Registers, hi),
+        LO_INDEX => offset_of!(Registers, lo),
+        _ => unreachable!("invalid register index"),
+    };
+    offset as i32
+}
+
+fn emit_exit(builder: &mut FunctionBuilder<'_>, state: &LoweringState, pc: Value, completed: u64) {
+    for register in 1..REGISTER_COUNT {
+        if state.dirty[register] {
+            builder.ins().store(
+                MemFlagsData::new(),
+                state.values[register].expect("dirty registers always have a value"),
+                state.registers,
+                register_offset(register),
+            );
+        }
+    }
+    builder.ins().store(
+        MemFlagsData::new(),
+        pc,
+        state.registers,
+        offset_of!(Registers, pc) as i32,
+    );
+    let completed = builder.ins().iconst(types::I64, completed as i64);
+    builder.ins().return_(&[completed]);
+}
+
+fn iconst_u32(builder: &mut FunctionBuilder<'_>, value: u32) -> Value {
+    builder.ins().iconst(types::I32, i64::from(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cpu::Cpu;
+    use crate::memory::Memory;
+
+    #[test]
+    fn register_layout_matches_jit_offsets() {
+        assert_eq!(register_offset(0), offset_of!(Registers, gpr) as i32);
+        assert_eq!(register_offset(HI_INDEX), offset_of!(Registers, hi) as i32);
+        assert_eq!(register_offset(LO_INDEX), offset_of!(Registers, lo) as i32);
+    }
+
+    #[test]
+    fn compilation_budget_preserves_colliding_hot_blocks() {
+        let instructions = [
+            (0x09 << 26) | (8 << 16) | 1,
+            (0x09 << 26) | (8 << 21) | (8 << 16) | 1,
+            (8 << 21) | (8 << 16) | (9 << 11) | 0x21,
+            (9 << 21) | (8 << 16) | (10 << 11) | 0x26,
+        ];
+        let first_start = 0x1000;
+        let second_start = first_start + 0x4000;
+        let mut engine = JitEngine::new();
+        let mut registers = Registers::new(first_start);
+        let mut memory = Memory::new();
+        let ram = memory.jit_ram_ptr();
+        let framebuffer = memory.jit_framebuffer_ptr();
+
+        for _ in 0..HOT_BLOCK_THRESHOLD {
+            let _ = engine.execute(
+                first_start,
+                &instructions,
+                instructions.len(),
+                &mut registers,
+                ram,
+                framebuffer,
+            );
+        }
+        assert!(engine.entries[&first_start].block.is_some());
+
+        registers.pc = second_start;
+        for _ in 0..HOT_BLOCK_THRESHOLD {
+            assert!(engine
+                .execute(
+                    second_start,
+                    &instructions,
+                    instructions.len(),
+                    &mut registers,
+                    ram,
+                    framebuffer,
+                )
+                .is_none());
+        }
+        assert!(engine.entries[&second_start].block.is_none());
+
+        for _ in 0..=COMPILE_COOLDOWN_FRAMES {
+            engine.begin_frame();
+        }
+        assert!(engine
+            .execute(
+                second_start,
+                &instructions,
+                instructions.len(),
+                &mut registers,
+                ram,
+                framebuffer,
+            )
+            .is_some());
+        assert!(engine.entries[&first_start].block.is_some());
+        assert!(engine.entries[&second_start].block.is_some());
+    }
+
+    #[test]
+    fn compiled_block_matches_interpreter_state() {
+        let start = 0x1000;
+        let instructions = [
+            (0x09 << 26) | (8 << 16) | 5,                  // addiu t0, zero, 5
+            (0x09 << 26) | (8 << 21) | (9 << 16) | 0xfffe, // addiu t1, t0, -2
+            (9 << 16) | (10 << 11) | (4 << 6),             // sll t2, t1, 4
+            (0x2b << 26) | (10 << 16) | 0x0200,            // sw t2, 0x200(zero)
+            (0x23 << 26) | (11 << 16) | 0x0200,            // lw t3, 0x200(zero)
+            (0x04 << 26) | (11 << 21) | (10 << 16) | 2,    // beq t3, t2, +2
+            (0x09 << 26) | (12 << 16) | 7,                 // addiu t4, zero, 7
+        ];
+
+        let mut compiler = Compiler::new().unwrap();
+        let block = compiler.compile(start, &instructions).unwrap().unwrap();
+        assert_eq!(block.instruction_count, instructions.len());
+
+        let mut jit_registers = Registers::new(start);
+        let mut jit_memory = Memory::new();
+        let ram = jit_memory.jit_ram_ptr();
+        let framebuffer = jit_memory.jit_framebuffer_ptr();
+        let completed = unsafe { (block.function)(&mut jit_registers, ram, framebuffer) };
+        assert_eq!(completed, instructions.len() as u64);
+
+        let mut interpreter = Cpu::new(start);
+        let mut interpreter_memory = Memory::new();
+        interpreter.start();
+        for &instruction in &instructions {
+            assert!(interpreter
+                .step_fetched_unaccounted(instruction, &mut interpreter_memory)
+                .unwrap());
+        }
+
+        assert_eq!(jit_registers.gpr, interpreter.regs.gpr);
+        assert_eq!(jit_registers.pc, interpreter.regs.pc);
+        assert_eq!(jit_registers.hi, interpreter.regs.hi);
+        assert_eq!(jit_registers.lo, interpreter.regs.lo);
+        assert_eq!(jit_memory.read_u32(0x200).unwrap(), 48);
+        assert_eq!(
+            jit_memory.read_u32(0x200).unwrap(),
+            interpreter_memory.read_u32(0x200).unwrap()
+        );
+    }
+
+    #[test]
+    fn extended_integer_and_unaligned_memory_match_interpreter() {
+        let start = 0x1800;
+        let instructions = [
+            (8 << 21) | (9 << 16) | 0x1a,             // div t0, t1
+            (10 << 11) | 0x12,                        // mflo t2
+            (11 << 11) | 0x10,                        // mfhi t3
+            (0x22 << 26) | (4 << 21) | (5 << 16) | 3, // lwl a1, 3(a0)
+            (0x26 << 26) | (4 << 21) | (5 << 16),     // lwr a1, 0(a0)
+            (0x2a << 26) | (6 << 21) | (7 << 16) | 3, // swl a3, 3(a2)
+            (0x2e << 26) | (6 << 21) | (7 << 16),     // swr a3, 0(a2)
+            (8 << 21) | (12 << 16) | 0x1a,            // div t0, t4
+            (13 << 11) | 0x12,                        // mflo t5
+            (14 << 11) | 0x10,                        // mfhi t6
+        ];
+        let mut compiler = Compiler::new().unwrap();
+        let block = compiler.compile(start, &instructions).unwrap().unwrap();
+
+        let mut jit_registers = Registers::new(start);
+        jit_registers.write(4, 0x101);
+        jit_registers.write(5, 0xdead_beef);
+        jit_registers.write(6, 0x201);
+        jit_registers.write(7, 0x4433_2211);
+        jit_registers.write(8, (-7i32) as u32);
+        jit_registers.write(9, 3);
+        jit_registers.write(12, 0);
+        let mut interpreter = Cpu::new(start);
+        interpreter.regs = jit_registers.clone();
+        interpreter.start();
+
+        let mut jit_memory = Memory::new();
+        let mut interpreter_memory = Memory::new();
+        for memory in [&mut jit_memory, &mut interpreter_memory] {
+            memory
+                .load_data(0x100, &[0x11, 0x22, 0x33, 0x44, 0x55])
+                .unwrap();
+            memory.load_data(0x200, &[0xaa; 8]).unwrap();
+        }
+        let ram = jit_memory.jit_ram_ptr();
+        let framebuffer = jit_memory.jit_framebuffer_ptr();
+        let completed = unsafe { (block.function)(&mut jit_registers, ram, framebuffer) };
+        for &instruction in &instructions {
+            interpreter
+                .step_fetched_unaccounted(instruction, &mut interpreter_memory)
+                .unwrap();
+        }
+
+        assert_eq!(completed, instructions.len() as u64);
+        assert_eq!(jit_registers.gpr, interpreter.regs.gpr);
+        assert_eq!(jit_registers.pc, interpreter.regs.pc);
+        assert_eq!(jit_registers.hi, interpreter.regs.hi);
+        assert_eq!(jit_registers.lo, interpreter.regs.lo);
+        assert_eq!(
+            &jit_memory.system_ram()[0x200..0x208],
+            &interpreter_memory.system_ram()[0x200..0x208]
+        );
+    }
+
+    #[test]
+    fn special_memory_mapping_bails_out_before_side_effects() {
+        let start = 0x2000;
+        let instructions = [
+            (0x2b << 26) | (9 << 21) | (8 << 16),
+            (0x09 << 26) | (10 << 16) | 1,
+        ];
+        let mut compiler = Compiler::new().unwrap();
+        let block = compiler.compile(start, &instructions).unwrap().unwrap();
+        let mut registers = Registers::new(start);
+        registers.write(8, 0x1234_5678);
+        registers.write(9, 0x1308_0000);
+        let mut memory = Memory::new();
+        let ram = memory.jit_ram_ptr();
+        let framebuffer = memory.jit_framebuffer_ptr();
+
+        let completed = unsafe { (block.function)(&mut registers, ram, framebuffer) };
+
+        assert_eq!(completed, 0);
+        assert_eq!(registers.pc, start);
+        assert_eq!(registers.read(10), 0);
+        assert_eq!(memory.read_u32(0x1308_0000).unwrap(), 0);
+    }
+
+    #[test]
+    fn framebuffer_alias_uses_native_memory_path() {
+        let start = 0x3000;
+        let instructions = [(0x2b << 26) | (9 << 21) | (8 << 16)];
+        let mut compiler = Compiler::new().unwrap();
+        let block = compiler.compile(start, &instructions).unwrap().unwrap();
+        let mut registers = Registers::new(start);
+        registers.write(8, 0x1234_5678);
+        registers.write(9, crate::video::VM_LCD_FB_ADDRESS);
+        let mut memory = Memory::new();
+        let ram = memory.jit_ram_ptr();
+        let framebuffer = memory.jit_framebuffer_ptr();
+
+        let completed = unsafe { (block.function)(&mut registers, ram, framebuffer) };
+
+        assert_eq!(completed, 1);
+        assert_eq!(registers.pc, start + 4);
+        assert_eq!(
+            memory.read_u32(crate::video::VM_LCD_FB_ADDRESS).unwrap(),
+            0x1234_5678
+        );
+    }
+}

--- a/crates/dingooemu-core/src/lib.rs
+++ b/crates/dingooemu-core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod cpu;
 pub mod emulator;
 pub mod error;
 pub mod input;
+#[cfg(feature = "jit")]
+mod jit;
 pub mod memory;
 mod save_state;
 pub mod video;

--- a/crates/dingooemu-core/src/memory.rs
+++ b/crates/dingooemu-core/src/memory.rs
@@ -3,13 +3,13 @@ use crate::video::FRAMEBUFFER_MAP_SIZE;
 
 /// Dingoo A320 memory regions
 const RAM_BASE: u32 = 0x0000_0000;
-const RAM_SIZE: u32 = 32 * 1024 * 1024; // 32 MB
+pub(crate) const RAM_SIZE: u32 = 32 * 1024 * 1024; // 32 MB
 
 /// MIPS KSEG0 mask (strip top 3 bits for cached segment)
 const KSEG0_MASK: u32 = 0x1FFF_FFFF;
 
 /// Guest-visible aliases for the LCD framebuffer mapping.
-const LCD_FRAMEBUFFER_ALIASES: [u32; 4] = [
+pub(crate) const LCD_FRAMEBUFFER_ALIASES: [u32; 4] = [
     crate::video::VM_LCD_FB_ADDRESS,
     0x1400_0000,
     0x9000_0000,
@@ -68,6 +68,18 @@ impl Memory {
             free_blocks: Vec::new(),
             write_log: Vec::new(),
         }
+    }
+
+    #[cfg(feature = "jit")]
+    #[inline(always)]
+    pub(crate) fn jit_ram_ptr(&mut self) -> *mut u8 {
+        self.ram.as_mut_ptr()
+    }
+
+    #[cfg(feature = "jit")]
+    #[inline(always)]
+    pub(crate) fn jit_framebuffer_ptr(&mut self) -> *mut u8 {
+        self.framebuffer.as_mut_ptr()
     }
 
     /// Get a copy of the write log and clear it

--- a/crates/dingooemu-libretro/Cargo.toml
+++ b/crates/dingooemu-libretro/Cargo.toml
@@ -15,5 +15,10 @@ name = "dingooemu"
 crate-type = ["cdylib"]
 
 [dependencies]
-dingooemu-core.workspace = true
 log.workspace = true
+
+[target.'cfg(all(target_os = "android", target_pointer_width = "64", any(target_arch = "aarch64", target_arch = "x86_64")))'.dependencies]
+dingooemu-core = { workspace = true, features = ["jit"] }
+
+[target.'cfg(not(all(target_os = "android", target_pointer_width = "64", any(target_arch = "aarch64", target_arch = "x86_64"))))'.dependencies]
+dingooemu-core.workspace = true

--- a/crates/dingooemu-libretro/src/api.rs
+++ b/crates/dingooemu-libretro/src/api.rs
@@ -382,6 +382,7 @@ struct CoreOptions {
     swap_ab: bool,
     debug_logging: bool,
     unknown_instruction_policy: UnknownInstructionPolicy,
+    jit_enabled: bool,
 }
 
 impl Default for CoreOptions {
@@ -393,12 +394,13 @@ impl Default for CoreOptions {
             swap_ab: false,
             debug_logging: false,
             unknown_instruction_policy: UnknownInstructionPolicy::Skip,
+            jit_enabled: true,
         }
     }
 }
 
 fn core_option_variables() -> Vec<RetroVariable> {
-    vec![
+    let mut variables = vec![
         RetroVariable {
             key: c"dingooemu_volume".as_ptr(),
             value: c"Audio Volume (%); 100|90|80|70|60|50|40|30|20|10|0".as_ptr(),
@@ -423,11 +425,21 @@ fn core_option_variables() -> Vec<RetroVariable> {
             key: c"dingooemu_unknown_instruction".as_ptr(),
             value: c"Unknown MIPS Instruction Policy; skip|stop".as_ptr(),
         },
-        RetroVariable {
-            key: ptr::null(),
-            value: ptr::null(),
-        },
-    ]
+    ];
+    #[cfg(all(
+        target_os = "android",
+        target_pointer_width = "64",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ))]
+    variables.push(RetroVariable {
+        key: c"dingooemu_cpu_engine".as_ptr(),
+        value: c"CPU Execution Engine; jit|interpreter".as_ptr(),
+    });
+    variables.push(RetroVariable {
+        key: ptr::null(),
+        value: ptr::null(),
+    });
+    variables
 }
 
 fn set_core_options() {
@@ -494,6 +506,9 @@ fn read_core_options(mut get: impl FnMut(&CStr) -> Option<String>) -> CoreOption
             UnknownInstructionPolicy::Skip
         };
     }
+    if let Some(engine) = get(c"dingooemu_cpu_engine") {
+        options.jit_enabled = engine != "interpreter";
+    }
     options
 }
 
@@ -508,14 +523,16 @@ fn apply_core_options(emulator: &mut Emulator) {
     emulator
         .cpu
         .set_unknown_instruction_policy(options.unknown_instruction_policy);
+    emulator.set_jit_enabled(options.jit_enabled);
     log::info!(
-        "Core options applied: volume={} repeat_delay={} repeat_period={} swap_ab={} debug_logging={} unknown_instruction={:?}",
+        "Core options applied: volume={} repeat_delay={} repeat_period={} swap_ab={} debug_logging={} unknown_instruction={:?} cpu_engine={}",
         options.volume,
         options.repeat_delay,
         options.repeat_period,
         options.swap_ab,
         options.debug_logging,
-        options.unknown_instruction_policy
+        options.unknown_instruction_policy,
+        if options.jit_enabled { "jit" } else { "interpreter" }
     );
 }
 
@@ -795,6 +812,27 @@ mod tests {
             })
             .unknown_instruction_policy,
             UnknownInstructionPolicy::Stop
+        );
+    }
+
+    #[test]
+    #[cfg(all(
+        target_os = "android",
+        target_pointer_width = "64",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ))]
+    fn cpu_engine_option_defaults_to_jit_and_allows_interpreter() {
+        let variables = core_option_variables();
+        assert_eq!(
+            unsafe { CStr::from_ptr(variables[6].key) },
+            c"dingooemu_cpu_engine"
+        );
+        assert!(read_core_options(|_| None).jit_enabled);
+        assert!(
+            !read_core_options(|key| {
+                (key == c"dingooemu_cpu_engine").then(|| "interpreter".to_string())
+            })
+            .jit_enabled
         );
     }
 

--- a/docs/Android-Libretro-Core.md
+++ b/docs/Android-Libretro-Core.md
@@ -34,6 +34,17 @@ If the Online Updater is not available, you can install the core manually:
    and copy `dingooemu_libretro.info` into RetroArch's `info/` directory.
 3. **Load** the core and content the same way as on desktop.
 
+## CPU execution engines
+
+The `arm64-v8a` and `x86_64` cores use a tiered JIT by default. Frequently
+executed MIPS32 blocks are translated to native code, while unsupported or
+low-frequency paths continue through the cached interpreter. Compilation is
+rate-limited to avoid introducing frame-time spikes while a game warms up.
+
+Use **Quick Menu → Core Options → CPU Execution Engine** to switch to
+`interpreter` for compatibility testing. The `armeabi-v7a` and `x86` cores
+always use the interpreter and do not expose this option.
+
 ## Building the Android core locally
 
 Building for Android requires the [Android NDK](https://developer.android.com/ndk)

--- a/docs/RetroArch-Core.md
+++ b/docs/RetroArch-Core.md
@@ -123,9 +123,14 @@ loads while content remains loaded.
 | Swap A/B Buttons | `disabled`, `enabled` | `disabled` | Exchanges the emulated A and B button meanings. |
 | CPU/HLE Debug Logging | `disabled`, `enabled` | `disabled` | Enables detailed interpreter and HLE records in the frontend log. |
 | Unknown MIPS Instruction Policy | `skip`, `stop` | `skip` | Logs and skips unsupported instructions or stops with an execution error. |
+| CPU Execution Engine (64-bit Android) | `jit`, `interpreter` | `jit` | Uses native translation for hot CPU blocks on arm64-v8a and x86_64 Android. Other targets and unsupported instructions use the interpreter. Select `interpreter` for compatibility testing. |
 
 Core option changes are applied while content is running and restored after a
 RetroArch reset.
+
+The JIT waits until a block has executed 256 times and rate-limits native
+compilation to one block every four frames. Short blocks and repeatedly
+unsupported memory paths remain on the interpreter to avoid runtime stutter.
 
 ## RetroPad Button Mapping
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DingooEmu — Dingoo A320 掌机模拟器</title>
-  <meta name="description" content="用 Rust 编写的 Dingoo A320 掌机模拟器，支持 MIPS32 CPU 模拟、Dingoo SDK HLE、RetroArch 核心">
+  <meta name="description" content="用 Rust 编写的 Dingoo A320 掌机模拟器，支持 MIPS32 CPU 模拟、64 位 Android JIT 加速、Dingoo SDK HLE 和 RetroArch 核心">
   <link rel="icon" type="image/png" href="res/logo-banner.png">
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -140,8 +140,8 @@
           <div class="feature-icon">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 9l3 3-3 3"/><path d="M15 15l-3-3 3-3"/></svg>
           </div>
-          <h3 data-i18n="feat-mips-title">MIPS32 CPU 模拟</h3>
-          <p data-i18n="feat-mips-desc">带直接映射指令块缓存的 MIPS32 XBurst 解释器，支持寄存器、内存管理、COP0 协处理器和异常处理。</p>
+          <h3 data-i18n="feat-mips-title">MIPS32 CPU 与 JIT</h3>
+          <p data-i18n="feat-mips-desc">全平台使用缓存解释器，64 位 Android 还可将高频 MIPS32 指令块动态翻译为本机代码，并对不支持的路径精确回退。</p>
         </div>
         <div class="feature-card fade-in-up">
           <div class="feature-icon">
@@ -223,7 +223,7 @@
               <strong>dingooemu-core</strong>
               <small data-i18n="arch-core-sub">平台无关的库</small>
               <div class="core-modules">
-                <span>MIPS CPU</span>
+                <span data-i18n="arch-cpu">MIPS CPU / JIT</span>
                 <span>Memory</span>
                 <span>Graphics</span>
                 <span>Audio</span>

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -56,7 +56,7 @@
     zh: {
       // meta
       'meta-title': 'DingooEmu — Dingoo A320 掌机模拟器',
-      'meta-desc': '用 Rust 编写的 Dingoo A320 掌机模拟器，支持 MIPS32 CPU 模拟、Dingoo SDK HLE、RetroArch 核心',
+      'meta-desc': '用 Rust 编写的 Dingoo A320 掌机模拟器，支持 MIPS32 CPU 模拟、64 位 Android JIT 加速、Dingoo SDK HLE 和 RetroArch 核心',
       // nav
       'nav-features': '核心特性',
       'nav-games': '游戏库',
@@ -89,8 +89,8 @@
       // features
       'feat-title': '核心特性',
       'feat-subtitle': '从 MIPS CPU 到 Dingoo SDK，全栈 Rust 实现',
-      'feat-mips-title': 'MIPS32 CPU 模拟',
-      'feat-mips-desc': '带直接映射指令块缓存的 MIPS32 XBurst 解释器，支持寄存器、内存管理、COP0 协处理器和异常处理。',
+      'feat-mips-title': 'MIPS32 CPU 与 JIT',
+      'feat-mips-desc': '全平台使用缓存解释器，64 位 Android 还可将高频 MIPS32 指令块动态翻译为本机代码，并对不支持的路径精确回退。',
       'feat-sdk-title': 'Dingoo SDK HLE',
       'feat-sdk-desc': '高层模拟 Dingoo 原生 SDK，包括图形渲染、输入处理、音频播放、文件系统和多任务调度。',
       'feat-dual-title': '双前端架构',
@@ -114,6 +114,7 @@
       'arch-libretro-sub': 'libretro cdylib<br>RetroArch 核心',
       'arch-core': '核心引擎',
       'arch-core-sub': '平台无关的库',
+      'arch-cpu': 'MIPS CPU / JIT',
       'arch-platforms': '目标平台',
       // quickstart
       'qs-title': '快速开始',
@@ -147,7 +148,7 @@
     en: {
       // meta
       'meta-title': 'DingooEmu — Dingoo A320 Handheld Emulator',
-      'meta-desc': 'A Dingoo A320 handheld emulator written in Rust, supporting MIPS32 CPU emulation, Dingoo SDK HLE, and RetroArch core',
+      'meta-desc': 'A Dingoo A320 handheld emulator written in Rust with MIPS32 CPU emulation, 64-bit Android JIT acceleration, Dingoo SDK HLE, and a RetroArch core',
       // nav
       'nav-features': 'Features',
       'nav-games': 'Games',
@@ -180,8 +181,8 @@
       // features
       'feat-title': 'Core Features',
       'feat-subtitle': 'From MIPS CPU to Dingoo SDK — full-stack Rust implementation',
-      'feat-mips-title': 'MIPS32 CPU Emulation',
-      'feat-mips-desc': 'MIPS32 XBurst interpreter with a direct-mapped instruction block cache, register management, memory handling, COP0 coprocessor, and exception processing.',
+      'feat-mips-title': 'MIPS32 CPU & JIT',
+      'feat-mips-desc': 'A cached interpreter runs on every platform, while 64-bit Android can translate hot MIPS32 blocks to native code with precise fallback for unsupported paths.',
       'feat-sdk-title': 'Dingoo SDK HLE',
       'feat-sdk-desc': 'High-level emulation of Dingoo native SDK including graphics rendering, input handling, audio playback, filesystem, and multi-task scheduling.',
       'feat-dual-title': 'Dual Frontend',
@@ -205,6 +206,7 @@
       'arch-libretro-sub': 'libretro cdylib · RetroArch core',
       'arch-core': 'Core Engine',
       'arch-core-sub': 'Platform-independent library',
+      'arch-cpu': 'MIPS CPU / JIT',
       'arch-platforms': 'Platforms',
       // quickstart
       'qs-title': 'Quick Start',


### PR DESCRIPTION
## Summary

This PR adds a feature-gated Cranelift MIPS32-to-native JIT and enables it for 64-bit Android libretro builds. It is rebased directly onto `master` after #20 was merged.

The final design is deliberately tiered and conservative. An initial aggressive prototype compiled blocks after 16 executions without a per-frame budget; arm64 device testing showed that synchronous compilation and direct-mapped cache collisions could make real games much slower despite strong steady-state synthetic results. The implementation here raises the hot threshold, rate-limits compilation, preserves compiled blocks across cache collisions, and leaves low-value or unstable paths on the interpreter.

## Design

### Tiered execution

- Keep the cached interpreter as the correctness baseline and universal fallback.
- Count executions by full guest PC and compile only after 256 executions.
- Compile at most one block every four emulated frames.
- Skip translated prefixes shorter than four guest instructions.
- Cap JIT metadata at 32,768 guest PCs.
- Use a two-level native cache:
  - a 4,096-slot direct lookup for the steady-state hot path;
  - a full-PC hash map that retains compiled blocks when direct slots collide.
- Disable a native block after four consecutive zero-instruction exits so repeatedly unsupported memory paths stop paying JIT dispatch cost.
- Invalidate JIT lookups together with the existing instruction cache.
- Drop and recreate the Cranelift module after invalidation when native code was generated, releasing stale executable memory before blocks can be recompiled.

### MIPS coverage

The translator currently handles the high-value integer subset used by the runtime:

- immediate and register arithmetic/logic;
- fixed and variable shifts;
- conditional moves and comparisons;
- HI/LO moves, signed/unsigned multiply and divide;
- SPECIAL2 multiply-accumulate, multiply-subtract, MUL, CLZ, and CLO;
- direct and conditional branches, jumps, link operations, and branch delay slots;
- LB/LBU/LH/LHU/LW, SB/SH/SW, LL/SC;
- LWL/LWR/SWL/SWR unaligned memory operations;
- PREF and SYNC no-op behavior.

Unsupported instructions, unsafe branch-delay combinations, IPU registers, and other special mappings exit at the exact guest PC and resume in the interpreter.

### Memory fast paths

- Give translated code checked native access to the 32 MiB system RAM allocation.
- Route all four LCD framebuffer aliases to the shared framebuffer allocation.
- Branch to the common RAM path before evaluating framebuffer aliases, keeping normal loads and stores short.
- Preserve little-endian and KSEG0/KSEG1 address semantics.
- Keep IPU and unknown mappings on the existing checked memory implementation.

### Android integration

- Enable JIT only for Android arm64-v8a and x86_64 libretro builds.
- Keep 32-bit Android and non-Android targets on the interpreter.
- Add the live `CPU Execution Engine` core option with `jit` as the Android 64-bit default and `interpreter` as an A/B compatibility mode.
- Document the execution modes in the README, Android guide, RetroArch guide, and bilingual website.

### Licensing

DingooEmu source code remains BSD-3-Clause. JIT-enabled Android binaries additionally incorporate Cranelift/Wasmtime components under Apache-2.0 WITH LLVM-exception and `region` under MIT. The full compatible license texts are now tracked in `THIRD_PARTY_LICENSES.md`, and Android release/nightly archives include both `LICENSE` and `THIRD_PARTY_LICENSES.md`.

## Optimization results

Release-mode synthetic measurements on the development x86_64 host:

| Workload | Interpreter | JIT | Result |
| --- | ---: | ---: | ---: |
| Single hot integer/RAM loop, first frame | 10.7866 ms | 2.5882 ms | JIT uses 24% of interpreter time |
| Single hot integer/RAM loop, next 5 frames | 51.0660 ms | 7.2016 ms | 7.09x throughput improvement |
| 64 rotating hot blocks, first frame | 9.1018 ms | 9.6867 ms | 1.06x time during conservative warm-up |
| 64 rotating hot blocks, next 5 frames | 44.1228 ms | 43.4590 ms | 0.98x time; no compilation cascade |

The 64-block workload models a larger game working set and verifies that compilation stays bounded rather than monopolizing a frame.

Manual Android arm64 device validation of the final rate-limited build reported a substantial improvement over the aggressive prototype: the target 3D games are now largely smooth and essentially no longer stutter. This is qualitative device feedback rather than a fixed FPS claim.

## Validation

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo test --workspace`: passed across the workspace and integration tests.
- `cargo test -p dingooemu-core --features jit --lib`: 85 passed, 1 manual benchmark ignored.
- JIT/interpreter differential tests cover registers, branches and delay slots, division edge cases, aligned and unaligned memory, framebuffer aliases, special-mapping bailout, compilation budgets, colliding hot PCs, and compiler recreation after cache invalidation.
- The cache-invalidation regression test was verified to fail against the old clear-only implementation and pass after module recreation.
- `cargo build --release --target aarch64-linux-android -p dingooemu-libretro`: passed with Android NDK r29 / API 21.
- `cargo build --release --target x86_64-linux-android -p dingooemu-libretro`: passed with Android NDK r29 / API 21.
- Produced cores were verified as ELF64/AArch64 and ELF64/x86-64; both depend only on `libdl.so` and `libc.so`.
- The pre-push `cargo test --all` hook passed on the rebased five-commit branch.

## Commits

1. `cae73c2 feat(core): add tiered MIPS JIT backend`
   - Adds the Cranelift backend, checked memory routes, tiering policy, cache management, differential tests, and manual cold/hot benchmarks.
2. `380b805 feat(libretro): enable JIT on 64-bit Android`
   - Enables JIT for supported Android ABIs, adds the live core option, and documents the runtime policy.
3. `4f6f32e fix(core): release JIT code on cache invalidation`
   - Recreates the Cranelift module after invalidation so stale executable code is released, with a regression test that catches the old behavior.
4. `581d31b docs: document Android JIT execution`
   - Synchronizes README architecture, Android usage guidance, and bilingual website feature/architecture text.
5. `369eba8 build: bundle Android JIT licenses`
   - Adds complete compatible third-party license texts and includes project/third-party licenses in Android release and nightly archives.

## Limitations and follow-up

- Native compilation remains synchronous, but the policy bounds it to one block every four frames.
- Floating-point instructions are not translated because the current guest CPU path is integer-focused.
- Special device mappings continue through the interpreter by design.
- arm64 has qualitative device validation; x86_64 is cross-build validated but has not been tested on a physical Android x86_64 device.
- Further tuning should be driven by per-game hot-block and bailout telemetry rather than lowering the global threshold again.