### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,23 @@ libretro-build-linux-x64:
     - .libretro-rust-linux-x64-default
     - .core-defs
 
+# Linux aarch64
+# Cross-compiled from the same image as the x64 job, the way that image already
+# cross-compiles the Apple and Android arm64 targets. There is no
+# rust-linux-aarch64.yml template yet (libretro/libretro-super#2030) and the
+# rust image is amd64-only, so the target and its linker are added here.
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-rust-linux-x64
+    - .core-defs
+  variables:
+    TARGET_ARCH: aarch64-unknown-linux-gnu
+    STRIP: aarch64-linux-gnu-strip
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+  before_script:
+    - apt-get update -qy && apt-get install -yq gcc-aarch64-linux-gnu
+    - rustup target add aarch64-unknown-linux-gnu
+
 # macOS 64-bit
 libretro-build-osx-x64:
   extends:


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job so DingooEmu lands in `nightly/linux/aarch64/` on the buildbot, where it is currently missing. Same job you already merged into BBKEmu (AloysHF/BBKEmu#11) and Native32Emu (#94) — this is the rest of the list you asked about there.

### Why it is still not a one-liner

`rust-linux-aarch64.yml` in ci-templates still 404s (I raised the gap as libretro/libretro-super#2030 and have the template written for whoever has `ci-templates` access), and `libretro-build-rust` is `FROM libretro-build-amd64-ubuntu`, so there is no native aarch64 image to point at either.

So this job cross-compiles from the same image the x64 job already uses, in the style that image already uses for its other arm64 targets (it sets `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER` and friends): add the target, point `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` at `aarch64-linux-gnu-gcc`, and override `STRIP`, since the template's default `strip` is host binutils (`rust-webos.yml` does the same).

`.libretro-rust-linux-x64` is extended rather than `-default`, because that is what pins `TARGET_ARCH` to x86_64. When the template lands, this block collapses to an `extends:` line.

### Tested

Built on aarch64 Linux hardware (Snapdragon 7c / SC7180, postmarketOS), rustc 1.98.0, host `aarch64-unknown-linux-gnu`:

* **no source changes needed** — `cargo build --release` is clean across the workspace (2m 00s)
* `libdingooemu.so` comes out as an ELF 64-bit LSB shared object, ARM aarch64

**Build-verified only.** I have no legitimate way to obtain content for this core, so I could not boot it in RetroArch — if you have a redistributable sample I am happy to run it and report back.

**What I could not test:** I built natively on aarch64, whereas this job cross-compiles from x86_64, and a GitHub PR cannot run the GitLab pipeline, so the job itself has not been executed by CI. The identical block is in production in BBKEmu, where `libretro-build-linux-aarch64` passes on the buildbot.