### PR TITLE
feat: implement OSTaskDel HLE

### DIFF
--- a/crates/dingooemu-core/src/emulator.rs
+++ b/crates/dingooemu-core/src/emulator.rs
@@ -1006,6 +1006,34 @@ impl Emulator {
         true
     }
 
+    /// Delete a guest task using the uC/OS-II OSTaskDel convention.
+    ///
+    ///
+    /// Priority 0xff refers to the currently executing task. Guest task CPUs
+    /// are installed in `self.cpu` while scheduled, so stopping `self.cpu`
+    /// also handles deletion of the active task.
+    fn delete_guest_task(&mut self, priority: u32) -> bool {
+        const OS_PRIO_SELF: u32 = 0xff;
+
+        if priority == OS_PRIO_SELF {
+            self.cpu.stop();
+            return true;
+        }
+
+        if let Some(task_index) = self.active_task {
+            if self.tasks[task_index].priority == priority {
+                self.cpu.stop();
+                return true;
+            }
+        }
+
+        if let Some(task) = self.tasks.iter_mut().find(|task| task.priority == priority) {
+            task.cpu.stop();
+            return true;
+        }
+
+        false
+    }
     fn set_active_wait(&mut self, wait: TaskWait) {
         if let Some(task_index) = self.active_task {
             self.tasks[task_index].wait = Some(wait);

--- a/crates/dingooemu-core/src/emulator/sdk_hle/tasks.rs
+++ b/crates/dingooemu-core/src/emulator/sdk_hle/tasks.rs
@@ -15,6 +15,12 @@ pub(super) fn handle(emu: &mut Emulator, func_name: &str) -> Result<HandlerResul
                 emu.cpu.regs.read(2)
             );
         }
+        "OSTaskDel" => {
+            let priority = emu.cpu.regs.read(4);
+            let deleted = emu.delete_guest_task(priority);
+            emu.cpu.regs.write(2, if deleted { 0 } else { 1 });
+            log::trace!("  OSTaskDel({priority}) = {}", emu.cpu.regs.read(2));
+        }
         "OSSemCreate" => {
             let count = emu.cpu.regs.read(4);
             let handle = emu.create_semaphore(count);


### PR DESCRIPTION
## Summary

Implement the uC/OS-II `OSTaskDel` HLE call used by Dingoo SDK
applications.

The implementation supports:

- `OS_PRIO_SELF` (`0xff`) for deleting the currently executing task
- deleting the active guest task by priority
- deleting a scheduled guest task by priority
- returning a non-zero result when the requested task is not found

This allows applications and worker tasks to terminate normally instead of
falling through to the generic unknown-HLE compatibility stub.

## Testing

- `cargo fmt --all`
- `cargo test -p dingooemu-core`