### PR TITLE
fix: restore 22050 Hz libretro audio output

### DIFF
--- a/crates/dingooemu-core/src/audio.rs
+++ b/crates/dingooemu-core/src/audio.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 #[cfg(feature = "standalone")]
 use std::num::NonZero;
 
-pub const OUTPUT_SAMPLE_RATE: u32 = 48_000;
+pub const OUTPUT_SAMPLE_RATE: u32 = 22_050;
 
 #[cfg(not(feature = "standalone"))]
 const VIDEO_FRAMES_PER_SECOND: u32 = 60;

--- a/crates/dingooemu-core/src/audio.rs
+++ b/crates/dingooemu-core/src/audio.rs
@@ -515,4 +515,19 @@ mod tests {
             .iter()
             .all(|frame| frame[0] == frame[1]));
     }
+
+    #[cfg(not(feature = "standalone"))]
+    #[test]
+    fn preserves_fractional_audio_frames_at_22050_hz() {
+        let mut audio = Audio::new();
+        let frame_counts = (0..VIDEO_FRAMES_PER_SECOND)
+            .map(|_| audio.take_frame_samples().len() / 2)
+            .collect::<Vec<_>>();
+
+        assert_eq!(&frame_counts[..4], &[367, 368, 367, 368]);
+        assert_eq!(
+            frame_counts.iter().sum::<usize>(),
+            OUTPUT_SAMPLE_RATE as usize
+        );
+    }
 }

--- a/docs/Android-Libretro-Core.md
+++ b/docs/Android-Libretro-Core.md
@@ -61,7 +61,7 @@ contains timing and aggregate counters, not game data. It is refreshed once per
 second while enabled, so it can still be copied if the frontend cannot close
 content cleanly. The report includes cumulative and recent frame timing, video
 and audio callback costs, audio short writes, frontend buffer status,
-asynchronous queue statistics, the 48 kHz host output rate, and JIT execution
+asynchronous queue statistics, the 22.05 kHz host output rate, and JIT execution
 and fallback counters. The core leaves frontend latency settings unchanged.
 Audio produced while the frontend callback is disabled is discarded, and the
 active callback uses a short bounded queue to avoid stale playback.

--- a/docs/RetroArch-Core.md
+++ b/docs/RetroArch-Core.md
@@ -67,7 +67,7 @@ platform-specific installation requirements:
 ## Supported Features
 
 - Video output using the native RGB565 pixel format
-- PCM audio output resampled to 48 kHz stereo for common host audio devices
+- PCM audio output resampled to 22.05 kHz stereo
 - Asynchronous audio delivery when supported by the frontend, with automatic
   synchronous fallback
 - RetroPad input handling
@@ -137,7 +137,7 @@ unsupported memory paths remain on the interpreter to avoid runtime stutter.
 When diagnostics are enabled, the report is refreshed once per second and when
 content is unloaded. It includes cumulative and recent 60-frame timing,
 separate video and audio callback costs, audio short-write and frontend buffer
-status counters, asynchronous queue statistics, the 48 kHz output rate,
+status counters, asynchronous queue statistics, the 22.05 kHz output rate,
 plus JIT execution, compilation, and fallback counters. Supported frontends
 deliver audio outside the emulation thread so audio backpressure does not stall
 video and input. The core leaves frontend latency settings unchanged, discards


### PR DESCRIPTION
## Summary

Restore the libretro audio output sample rate from 48,000 Hz to 22,050 Hz.

The 48,000 Hz output rate introduced by `c27d19c` causes a significant
performance regression on the tested Android libretro frontend. Restoring
the previous 22,050 Hz rate recovers normal emulation performance while
retaining the asynchronous frontend audio delivery introduced by that
commit.

## Investigation

The regression was isolated with `git bisect`:

- Good: `59ad486`
- First bad commit: `c27d19c` (`fix: decouple frontend audio delivery (#26)`)

A minimal test build changing only `OUTPUT_SAMPLE_RATE` from `48_000` back
to `22_050` completely restored performance on the same Android device,
game, and test scenario.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dingooemu-core`
- `cargo test -p dingooemu-libretro`
- `cargo clippy -- -D warnings`
- Android ARM64 core rebuilt successfully
- DingooBox Debug APK built and installed successfully
- Normal emulation performance restored in device testing
- Audio output remained functional
- In-game exit and save-state behavior remained functional