### PR TITLE
ci: add 32-bit Linux and Windows builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -32,6 +32,10 @@ jobs:
           - platform: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: dingoo-emu-linux-aarch64
+          - platform: ubuntu-22.04
+            target: i686-unknown-linux-gnu
+            artifact: dingoo-emu-linux-i686
+            libretro_only: true
           - platform: macos-latest
             target: x86_64-apple-darwin
             artifact: dingoo-emu-macos-x86_64
@@ -41,6 +45,10 @@ jobs:
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: dingoo-emu-windows-x86_64
+          - platform: windows-latest
+            target: i686-pc-windows-msvc
+            artifact: dingoo-emu-windows-i686
+            libretro_only: true
 
     runs-on: ${{ matrix.platform }}
 
@@ -73,7 +81,15 @@ jobs:
           sudo apt-get install -y libasound2-dev libx11-dev libxkbcommon-dev
         timeout-minutes: 10
 
+      - name: Install 32-bit Linux build dependencies
+        if: matrix.target == 'i686-unknown-linux-gnu'
+        run: sudo apt-get install -y gcc-multilib
+
       - name: Build standalone
+        # The standalone frontend needs a full set of 32-bit desktop dev
+        # packages on the runner; the 32-bit targets exist for RetroArch, so
+        # they build the core only, the way the GitLab jobs do.
+        if: ${{ !matrix.libretro_only }}
         run: cargo build -p dingooemu --release --target ${{ matrix.target }}
 
       - name: Build libretro core
@@ -116,7 +132,7 @@ jobs:
           cd ..
 
       - name: Package (Unix)
-        if: runner.os != 'Windows'
+        if: ${{ runner.os != 'Windows' && !matrix.libretro_only }}
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
@@ -124,7 +140,7 @@ jobs:
           cd ../../..
 
       - name: Package (Windows)
-        if: runner.os == 'Windows'
+        if: ${{ runner.os == 'Windows' && !matrix.libretro_only }}
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
@@ -377,7 +393,8 @@ jobs:
 
           - Built: $DATETIME
           - Commit: [\`$SHORT_SHA\`](https://github.com/$REPO/commit/${{ github.sha }})
-          - Platforms: Windows x86_64, macOS x86_64/aarch64, Linux x86_64/aarch64
+          - Platforms: Windows x86_64/i686, macOS x86_64/aarch64, Linux x86_64/aarch64/i686
+            (the 32-bit i686 builds are libretro cores only, no standalone binary)
           - Includes the standalone emulator and the libretro core (\`*-libretro.*\`) for RetroArch
           - Android libretro core (\`dingoo-emu-android-libretro.tar.gz\`) with arm64-v8a, armeabi-v7a, x86 and x86_64 ABIs
           - iOS libretro core (\`dingoo-emu-ios-libretro.tar.gz\`) for real devices (arm64) and simulators

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
           - platform: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: dingoo-emu-linux-aarch64
+          - platform: ubuntu-22.04
+            target: i686-unknown-linux-gnu
+            artifact: dingoo-emu-linux-i686
+            libretro_only: true
           - platform: macos-latest
             target: x86_64-apple-darwin
             artifact: dingoo-emu-macos-x86_64
@@ -29,6 +33,10 @@ jobs:
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: dingoo-emu-windows-x86_64
+          - platform: windows-latest
+            target: i686-pc-windows-msvc
+            artifact: dingoo-emu-windows-i686
+            libretro_only: true
 
     runs-on: ${{ matrix.platform }}
 
@@ -52,7 +60,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev libx11-dev libxkbcommon-dev
 
+      - name: Install 32-bit Linux build dependencies
+        if: matrix.target == 'i686-unknown-linux-gnu'
+        run: sudo apt-get install -y gcc-multilib
+
       - name: Build standalone
+        # The standalone frontend needs a full set of 32-bit desktop dev
+        # packages on the runner; the 32-bit targets exist for RetroArch, so
+        # they build the core only, the way the GitLab jobs do.
+        if: ${{ !matrix.libretro_only }}
         run: cargo build -p dingooemu --release --target ${{ matrix.target }}
 
       - name: Build libretro core
@@ -79,14 +95,14 @@ jobs:
           ls -la "$out"
 
       - name: Package (Unix)
-        if: runner.os != 'Windows'
+        if: ${{ runner.os != 'Windows' && !matrix.libretro_only }}
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../${{ matrix.artifact }}.tar.gz dingoo-emu
           cd ../../..
 
       - name: Package (Windows)
-        if: runner.os == 'Windows'
+        if: ${{ runner.os == 'Windows' && !matrix.libretro_only }}
         run: |
           cd target/${{ matrix.target }}/release
           7z a ../../../${{ matrix.artifact }}.zip dingoo-emu.exe
@@ -333,6 +349,8 @@ jobs:
             ### libretro core (for RetroArch)
             - Files ending in `-libretro.*` contain `dingooemu_libretro.<ext>`,
               ready to drop into RetroArch.
+            - 32-bit builds ship the core only: `dingoo-emu-linux-i686-libretro.tar.gz`
+              and `dingoo-emu-windows-i686-libretro.zip`.
 
             ### Android libretro core (for RetroArch on Android)
             - `dingoo-emu-android-libretro.tar.gz` contains

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,13 @@ libretro-build-windows-x64:
 # Windows 32-bit
 # The image ships the 32-bit mingw toolchain alongside the 64-bit one, so as
 # above: the target, plus the linker rustc would otherwise guess wrong.
+#
+# That mingw is gcc 7.3-win32, which on 32-bit x86 uses SJLJ exceptions, while
+# rustc's i686-pc-windows-gnu expects DWARF-2 unwinding: its libgcc_eh has no
+# _Unwind_Resume, so linking the precompiled std fails. (The 64-bit job is
+# unaffected — it uses SEH.) Building std from source with panic=abort removes
+# the unwinding machinery altogether, which is also the sounder behaviour for a
+# cdylib: a Rust panic must not unwind across the libretro C boundary.
 libretro-build-windows-i686:
   extends:
     - .libretro-rust-windows-x64
@@ -57,8 +64,12 @@ libretro-build-windows-i686:
   variables:
     TARGET_ARCH: i686-pc-windows-gnu
     CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER: i686-w64-mingw32-gcc
+    RUSTFLAGS: "-Cpanic=abort"
   before_script:
-    - rustup target add i686-pc-windows-gnu
+    - rustup toolchain install nightly --component rust-src
+    - rustup +nightly target add i686-pc-windows-gnu
+  script:
+    - cargo +nightly build --release --target ${TARGET_ARCH} -Z build-std=std,panic_abort
 
 # Linux 64-bit
 libretro-build-linux-x64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,11 +47,36 @@ libretro-build-windows-x64:
     - .libretro-rust-windows-x64-default
     - .core-defs
 
+# Windows 32-bit
+# The image ships the 32-bit mingw toolchain alongside the 64-bit one, so as
+# above: the target, plus the linker rustc would otherwise guess wrong.
+libretro-build-windows-i686:
+  extends:
+    - .libretro-rust-windows-x64
+    - .core-defs
+  variables:
+    TARGET_ARCH: i686-pc-windows-gnu
+    CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER: i686-w64-mingw32-gcc
+  before_script:
+    - rustup target add i686-pc-windows-gnu
+
 # Linux 64-bit
 libretro-build-linux-x64:
   extends:
     - .libretro-rust-linux-x64-default
     - .core-defs
+
+# Linux 32-bit
+# Same image and template as the x64 job, only the target changes: the image
+# already carries gcc-multilib, so all this needs is the rustup target.
+libretro-build-linux-i686:
+  extends:
+    - .libretro-rust-linux-x64
+    - .core-defs
+  variables:
+    TARGET_ARCH: i686-unknown-linux-gnu
+  before_script:
+    - rustup target add i686-unknown-linux-gnu
 
 # Linux aarch64
 # Cross-compiled from the same image as the x64 job, the way that image already

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,18 @@ libretro-build-windows-x64:
 # unaffected — it uses SEH.) Building std from source with panic=abort removes
 # the unwinding machinery altogether, which is also the sounder behaviour for a
 # cdylib: a Rust panic must not unwind across the libretro C boundary.
+#
+# The build image already provides nightly with rust-src, so the toolchain is
+# not reinstalled here: rustup replacing a component that lives in an image
+# layer fails with "Invalid cross-device link".
+#
+# The rustup target is still needed even though std is built from source:
+# rsbegin.o and rsend.o, which every windows-gnu link pulls in, come from
+# library/rtstartup and are built by the compiler's own bootstrap, not by
+# cargo. -Z build-std does not produce them (wg-cargo-std-aware#46), so without
+# the precompiled target the link fails with "rsbegin.o: No such file or
+# directory". Only those two objects are taken from it; the std that gets
+# linked is the one built here.
 libretro-build-windows-i686:
   extends:
     - .libretro-rust-windows-x64
@@ -66,8 +78,7 @@ libretro-build-windows-i686:
     CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER: i686-w64-mingw32-gcc
     RUSTFLAGS: "-Cpanic=abort"
   before_script:
-    - rustup toolchain install nightly --component rust-src
-    - rustup +nightly target add i686-pc-windows-gnu
+    - rustup +nightly target add ${TARGET_ARCH}
   script:
     - cargo +nightly build --release --target ${TARGET_ARCH} -Z build-std=std,panic_abort
 


### PR DESCRIPTION
The buildbot currently gets x86_64 and aarch64 Linux, x86_64 Windows, macOS, iOS/tvOS and all four Android ABIs — the two 32-bit desktop targets are the gap, and RetroArch still ships i686 builds for both platforms. Same change as AloysHF/BBKEmu#19, with the GitHub workflows kept in sync as you asked for there.

**GitLab** — nothing new is needed: `rust-linux-x64.yml` and `rust-windows-x64.yml` are generic over `TARGET_ARCH`, and the rust build image already carries `gcc-multilib` and the 32-bit mingw toolchain next to the 64-bit one. So each job is its 64-bit sibling with a different target, plus `rustup target add` in `before_script` — the same shape the aarch64 job already has. Windows also gets `CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER`, which rustc would otherwise guess wrong.

**GitHub** — `release.yml` and `nightly-build.yml` carry the same target list, so they get the two targets as well: `i686-unknown-linux-gnu` on ubuntu-22.04 (with `gcc-multilib`) and `i686-pc-windows-msvc` on windows-latest, where MSVC cross-compiles to x86 out of the box. Both entries are marked `libretro_only: true` and the standalone build/package steps skip them — the standalone frontend would need a full set of 32-bit desktop dev packages on the runner, while the GitLab jobs build the core alone anyway. The release notes mention that.

Built both targets on GitHub runners against the current tree:

- `i686-unknown-linux-gnu` → `ELF 32-bit LSB shared object, Intel 80386`, exporting `retro_run`
- `i686-pc-windows-msvc` → `PE32 executable (DLL), Intel i386`
